### PR TITLE
TECH-466: Employer with no applications and claim forms can't get to landing page (removed sensitive)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ web_modules/
 
 # Optional npm cache directory
 .npm
+.npmrc
 
 # Optional eslint cache
 .eslintcache

--- a/packages/employer-client/src/Applications/ApplicationCreate.tsx
+++ b/packages/employer-client/src/Applications/ApplicationCreate.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { useEffect, useState } from "react"
 import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
 import { LoadingIndicator, useCreate, useGetIdentity, useGetList, useRedirect } from "react-admin"
@@ -11,7 +11,7 @@ export const ApplicationCreate = () => {
     const redirect = useRedirect()
     const { identity } = useGetIdentity()
     const [create] = useCreate()
-    const [loading, setLoading] = React.useState(false)
+    const [loading, setLoading] = useState(false)
     const { total, isLoading } = useGetList("applications", { pagination: { page: 1, perPage: 1 } })
     const [searchParams] = useSearchParams()
 
@@ -34,7 +34,7 @@ export const ApplicationCreate = () => {
         }
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (searchParams.get("redirectType") === "firstload" && total !== 0) {
             redirect("list", "applications")
         }

--- a/packages/employer-client/src/Applications/ApplicationCreate.tsx
+++ b/packages/employer-client/src/Applications/ApplicationCreate.tsx
@@ -1,16 +1,19 @@
+import React from "react"
 import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
-import { LoadingIndicator, useCreate, useGetIdentity, useRedirect } from "react-admin"
+import { LoadingIndicator, useCreate, useGetIdentity, useGetList, useRedirect } from "react-admin"
 import { v4 as uuidv4 } from "uuid"
 import BCGovPrimaryButton from "../common/components/BCGovPrimaryButton/BCGovPrimaryButton"
 import Card from "../common/components/Card/Card"
-import { useState } from "react"
+import { useSearchParams } from "react-router-dom"
 
 export const ApplicationCreate = () => {
     const redirect = useRedirect()
     const { identity } = useGetIdentity()
     const [create] = useCreate()
-    const [loading, setLoading] = useState(false)
+    const [loading, setLoading] = React.useState(false)
+    const { total, isLoading } = useGetList("applications", { pagination: { page: 1, perPage: 1 } })
+    const [searchParams] = useSearchParams()
 
     const handleClick = async (formType) => {
         if (identity?.guid) {
@@ -30,6 +33,12 @@ export const ApplicationCreate = () => {
             )
         }
     }
+
+    React.useEffect(() => {
+        if (searchParams.get("redirectType") === "firstload" && total !== 0) {
+            redirect("list", "applications")
+        }
+    }, [isLoading, redirect, searchParams, total])
 
     return (
         <Box paddingTop="6em" paddingBottom="3em" width="100%" display="flex" justifyContent="center" minWidth="58em">

--- a/packages/employer-client/src/Claims/ClaimCreate.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreate.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { useEffect } from "react"
 import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
 import { useGetList, useRedirect } from "react-admin"
@@ -11,7 +11,7 @@ export const ClaimCreate = () => {
     const { total, isLoading } = useGetList("claims", { pagination: { page: 1, perPage: 1 } })
     const [searchParams] = useSearchParams()
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (searchParams.get("redirectType") === "firstload" && total !== 0) {
             redirect("list", "claims")
         }

--- a/packages/employer-client/src/Claims/ClaimCreate.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreate.tsx
@@ -1,11 +1,21 @@
+import React from "react"
 import Box from "@mui/material/Box"
 import Grid from "@mui/material/Grid"
-import { useRedirect } from "react-admin"
+import { useGetList, useRedirect } from "react-admin"
 import BCGovPrimaryButton from "../common/components/BCGovPrimaryButton/BCGovPrimaryButton"
 import Card from "../common/components/Card/Card"
+import { useSearchParams } from "react-router-dom"
 
 export const ClaimCreate = () => {
     const redirect = useRedirect()
+    const { total, isLoading } = useGetList("claims", { pagination: { page: 1, perPage: 1 } })
+    const [searchParams] = useSearchParams()
+
+    React.useEffect(() => {
+        if (searchParams.get("redirectType") === "firstload" && total !== 0) {
+            redirect("list", "claims")
+        }
+    }, [isLoading, redirect, searchParams, total])
 
     return (
         <Box paddingTop="6em" paddingBottom="3em" width="100%" display="flex" justifyContent="center" minWidth="58em">

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -47,7 +47,7 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
         }
         if (!isFetching && statusFilter.label === "All" && total === 0) {
             setStatusFilter(statusFilters["All"])
-            redirect("create", resource)
+            redirect("create?redirectType=firstload", resource)
         }
     }, [isFetching])
 


### PR DESCRIPTION
This was happening due to the application redirecting to the create screen and the user would remain there if they continue to refresh the page.

Description of changes:

- Added a checker on ClaimCreate and ApplicationCreate to check for current total amount of applications returned, is the amount is not 0 then redirect to the main list page.