### PR TITLE
TECH-488: bug fix: display correct Submitted count in employer status sidebar

### DIFF
--- a/packages/employer-api/src/services/application.service.ts
+++ b/packages/employer-api/src/services/application.service.ts
@@ -22,7 +22,7 @@ export const getAllApplications = async (
                 queryBuilder.where("id", filters.id)
             }
             if (filters.status) {
-                queryBuilder.where("status", filters.status)
+                queryBuilder.whereIn("status", filters.status)
             }
             if (filters.form_confirmation_id) {
                 queryBuilder.where("form_confirmation_id", filters.form_confirmation_id)

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -9,11 +9,11 @@ import { DatagridStyles } from "../common/styles/DatagridStyles"
 
 export const applicationStatusFilters = {
     All: { label: "All" },
-    NotSubmitted: { label: "Draft", status: "Draft" },
-    Submitted: { label: "Submitted", status: "New" },
-    Processing: { label: "Processing", status: "In Progress" },
-    Completed: { label: "Completed", status: "Completed" },
-    Cancelled: { label: "Cancelled", status: "Cancelled" }
+    NotSubmitted: { label: "Draft", status: ["Draft"] },
+    Submitted: { label: "Submitted", status: ["New"] },
+    Processing: { label: "Processing", status: ["In Progress"] },
+    Completed: { label: "Completed", status: ["Completed"] },
+    Cancelled: { label: "Cancelled", status: ["Cancelled"] }
 } as { [key: string]: any }
 
 export const ApplicationList = (props: any) => {

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -1,5 +1,5 @@
 import { Box, ListItemText, MenuItem, MenuList } from "@mui/material"
-import { Count, useDataProvider, useListContext, useRedirect } from "react-admin"
+import { useDataProvider, useListContext, useRedirect } from "react-admin"
 import isEqual from "lodash/isEqual"
 import { ScreenReaderOnly } from "../../styles/ScreenReaderOnly"
 import { useEffect, useState } from "react"
@@ -16,29 +16,53 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
     const { resource, total, isFetching } = useListContext()
     const dataProvider = useDataProvider()
     const redirect = useRedirect()
-    const [counts, setCounts] = useState<any>(
-        Object.entries(statusFilters).reduce((acc: any, [key, val]) => {
-            acc[val?.status ? val.status : "All"] = 0
+
+    // A single label in the status sidebar may correspond to multiple statuses internally.
+    // So initialize two mappings:
+    //     status -> label
+    //     label -> count
+    // Then to obtain counts by status:
+    //     counts[labels[status]]
+
+    const createCountsObject = () => {
+        return Object.entries(statusFilters).reduce((acc: any, [key, val]) => {
+            acc[val.label] = 0
             return acc
         }, {} as Record<string, number>)
-    )
+    }
+
+    const createLabelsObject = () => {
+        return Object.entries(statusFilters).reduce((acc: any, [key, val]) => {
+            val?.status
+                ? val.status.forEach((status) => {
+                      acc[status] = val.label
+                  })
+                : (acc["All"] = "All")
+            return acc
+        }, {} as Record<string, number>)
+    }
+
+    const [counts, setCounts] = useState<any>(() => createCountsObject())
+    const [labels] = useState<any>(() => createLabelsObject())
+
+    const getCounts = () => {
+        dataProvider.getCounts(resource).then(({ data }) => {
+            const newCounts = createCountsObject()
+            let total = 0
+            data.forEach((item) => {
+                newCounts[labels[item.status]] += Number(item.count)
+                total += Number(item.count)
+            })
+            newCounts["All"] = total
+            setCounts(newCounts)
+        })
+    }
 
     const skipToDatagrid = (event: any) => {
         if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
             const element = document.getElementById("datagrid")
             element?.focus()
         }
-    }
-
-    const getCounts = () => {
-        dataProvider.getCounts(resource).then(({ data }) => {
-            const total = data.reduce((acc, val) => acc + Number(Object(val).count), 0)
-            const byStatus = data.reduce((acc, val) => {
-                acc[val.status] = Number(val.count)
-                return acc
-            }, {} as Record<string, number>)
-            setCounts({ All: total, ...byStatus })
-        })
     }
 
     useEffect(() => {
@@ -86,8 +110,8 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
                         <span style={{ color: COLOURS.MEDIUMGREY }}>
                             {statusFilters[key].label === "All"
                                 ? counts["All"]
-                                : statusFilters[key].status in counts
-                                ? counts[statusFilters[key].status]
+                                : statusFilters[key].label in counts
+                                ? counts[statusFilters[key].label]
                                 : "0"}
                         </span>
                         <span style={ScreenReaderOnly}>

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -43,7 +43,7 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
     }
 
     const [counts, setCounts] = useState<any>(() => createCountsObject())
-    const [labels] = useState<any>(() => createLabelsObject())
+    const labels = createLabelsObject()
 
     const getCounts = () => {
         dataProvider.getCounts(resource).then(({ data }) => {


### PR DESCRIPTION
In the employer client status sidebar, the number of 'Submitted' claims was sometimes incorrect.

This was because in the employer client, multiple internal statuses ('New', 'In Progress', and 'Completed') correspond to the 'Submitted' label in the sidebar. The previous code didn't handle this correctly.

This pull request addresses this issue by using two mappings to manage the status sidebar state:

{ status: label }
{ label: count }

Then we can obtain counts both by label and internal status value as required, ie:

counts[labels[status]]

or

counts[label]