### PR TITLE
TECH-502: Employer client: redirect from empty list loops on first load

### DIFF
--- a/packages/employer-client/src/Applications/ApplicationCreate.tsx
+++ b/packages/employer-client/src/Applications/ApplicationCreate.tsx
@@ -35,7 +35,7 @@ export const ApplicationCreate = () => {
     }
 
     useEffect(() => {
-        if (searchParams.get("redirectType") === "firstload" && total !== 0) {
+        if (searchParams.get("redirectType") === "firstload" && typeof total === "number" && total !== 0) {
             redirect("list", "applications")
         }
     }, [isLoading, redirect, searchParams, total])

--- a/packages/employer-client/src/Claims/ClaimCreate.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreate.tsx
@@ -12,7 +12,7 @@ export const ClaimCreate = () => {
     const [searchParams] = useSearchParams()
 
     useEffect(() => {
-        if (searchParams.get("redirectType") === "firstload" && total !== 0) {
+        if (searchParams.get("redirectType") === "firstload" && typeof total === "number" && total !== 0) {
             redirect("list", "claims")
         }
     }, [isLoading, redirect, searchParams, total])


### PR DESCRIPTION
Cause of issue: instead of returning a promise, the useGetList returns undefined on total before changing it to a number. This is satisfying the total !== 0 condition since undefined !== 0 = True.
Description of changes:
- Added a type check for number then check if it's a 0, on first load and useGetList has not returned, where total is undefined, it would not redirect back to list until total has been changed to a number.