### PR TITLE
Only permit business bceid users to access Share dialog.

### DIFF
--- a/packages/admin-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
+++ b/packages/admin-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
@@ -1,4 +1,4 @@
-import { Datagrid, DatagridBody } from "react-admin"
+import { Datagrid, DatagridBody, useGetIdentity } from "react-admin"
 import CustomDatagridRow from "../CustomDatagridRow/CustomDatagridRow"
 import { CustomDatagridHeader } from "../CustomDatagridHeader/CustomDatagridHeader"
 import { FormBulkActionButtons } from "../FormBulkActionButtons/FormBulkActionButtons"
@@ -25,12 +25,12 @@ const CustomDatagridBody = <T,>({ showCalculatorButton, ...props }: CustomDatagr
 }
 
 const CustomDatagrid = <T,>({ ariaLabel, showCalculatorButton, ...props }: CustomDatagridProps<T>) => {
+    const { identity } = useGetIdentity()
     const [hasBulkActions, setHasBulkActions] = useState<boolean>(false)
 
     useEffect(() => {
-        const provider = localStorage.getItem("provider")
-        setHasBulkActions(provider !== null && provider === "IDIR")
-    }, [])
+        setHasBulkActions(identity && identity?.idp && identity.idp === "idir")
+    }, [identity])
 
     const skipToListAside = (event: any) => {
         if (event.key === "ArrowLeft" || event.key === "ArrowRight") {

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -2,7 +2,6 @@ import { Box, Chip } from "@mui/material"
 import { useState } from "react"
 import { FunctionField, Identifier, List, TextField, useGetIdentity, useRedirect } from "react-admin"
 import CustomDatagrid from "../common/components/CustomDatagrid/CustomDatagrid"
-import { FormBulkActionButtons } from "../common/components/FormBulkActionButtons/FormBulkActionButtons"
 import { ListActions } from "../common/components/ListActions/ListActions"
 import { ListAside } from "../common/components/ListAside/ListAside"
 import { DatagridStyles } from "../common/styles/DatagridStyles"
@@ -53,12 +52,7 @@ export const ApplicationList = (props: any) => {
                             order: "DESC,DESC,DESC"
                         }}
                     >
-                        <CustomDatagrid
-                            bulkActionButtons={<FormBulkActionButtons />}
-                            sx={DatagridStyles}
-                            rowClick={handleRowClick}
-                            ariaLabel="applications list"
-                        >
+                        <CustomDatagrid sx={DatagridStyles} rowClick={handleRowClick} ariaLabel="applications list">
                             <TextField label="Submission ID" source="form_confirmation_id" emptyText="-" />
                             <TextField label="Position Title" source="position_title" emptyText="-" />
                             <TextField label="Number of Positions" source="num_positions" emptyText="-" />{" "}

--- a/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
+++ b/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
@@ -1,6 +1,8 @@
-import { Datagrid, DatagridBody } from "react-admin"
+import { Datagrid, DatagridBody, useGetIdentity } from "react-admin"
 import CustomDatagridRow from "./CustomDatagridRow"
 import { CustomDatagridHeader } from "./CustomDatagridHeader"
+import { useEffect, useState } from "react"
+import { FormBulkActionButtons } from "../FormBulkActionButtons/FormBulkActionButtons"
 
 // CustomDatagrid:
 // - Each row includes a PDF button.
@@ -29,6 +31,13 @@ const CustomDatagridBody = <T,>({ rowAriaLabel, showCalculatorButton, ...props }
 }
 
 const CustomDatagrid = <T,>({ ariaLabel, showCalculatorButton, rowAriaLabel, ...props }: CustomDatagridProps<T>) => {
+    const { identity } = useGetIdentity()
+    const [hasBulkActions, setHasBulkActions] = useState<boolean>(false)
+
+    useEffect(() => {
+        setHasBulkActions(identity && identity.businessGuid && identity.businessName)
+    }, [identity])
+
     const skipToListAside = (event: any) => {
         if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
             const element = document.getElementById("list-aside")
@@ -38,6 +47,7 @@ const CustomDatagrid = <T,>({ ariaLabel, showCalculatorButton, rowAriaLabel, ...
     return (
         <Datagrid
             {...props}
+            bulkActionButtons={hasBulkActions ? <FormBulkActionButtons /> : false}
             body={<CustomDatagridBody rowAriaLabel={rowAriaLabel} showCalculatorButton={showCalculatorButton} />}
             header={<CustomDatagridHeader />}
             aria-label={ariaLabel}


### PR DESCRIPTION
Previously in the employer client, basic bceid users could open the Share dialog by selecting the checkbox on a list row, then clicking 'Share' in the form bulk actions menu. Only business bceid users should be able to access the Share dialog.

This pull request prevents basic bceid users from accessing the Share dialog by disabling list row checkboxes and the form bulk actions menu for basic bceid users.