### PR TITLE
FullAddress is now an object with {address,city,province} for use in form validation

### DIFF
--- a/packages/form-api/src/services/geocoder.service.ts
+++ b/packages/form-api/src/services/geocoder.service.ts
@@ -21,7 +21,6 @@ export const geocodeAddress = async (address: string, city: string, province: st
         .post(`http://geocoder.api.gov.bc.ca/addresses.geojson?addressString=${address},${city},${province}`)
         .then((response) => {
             const { score } = response.data.features[0].properties
-            const { fullAddress } = response.data.features[0].properties
             const catchment = getCatchment(
                 response.data.features[0].geometry.coordinates[0],
                 response.data.features[0].geometry.coordinates[1]
@@ -29,7 +28,11 @@ export const geocodeAddress = async (address: string, city: string, province: st
             Catchment = catchment.closestCatchment
             Storefront = catchment.closestStorefrontId
             Score = score
-            FullAddress = fullAddress
+            FullAddress = {
+                address: `${response.data.features[0].properties.fullAddress.split(",")[0]}`,
+                city: response.data.features[0].properties.localityName,
+                province: response.data.features[0].properties.provinceCode
+            }
         })
     return { Score, FullAddress, Catchment, Storefront }
 }


### PR DESCRIPTION
Cause:
- Form validation would only return the Full Address as 1 string, this will require us to split on CHEFS side.
Description of changes:
- Utilizing the returned object properties from the Geocode API, FullAdress now is an object to be used in CHEFS to replace the user's address fields on validation.