### PR TITLE
TECH-543: always display form in correct editing mode

### DIFF
--- a/packages/admin-client/src/App.tsx
+++ b/packages/admin-client/src/App.tsx
@@ -239,7 +239,7 @@ const CustomAdminWithKeycloak = () => {
                     <Resource name="applications" options={{ label: "Applications" }} list={ApplicationList} />
                     <Resource name="claims" options={{ label: "Claims" }} list={ClaimList} />
                     <CustomRoutes>
-                        <Route path="ViewForm/:urlType/:resource/:formId/:recordId" element={<ViewForm />} />
+                        <Route path="ViewForm/:resource/:recordId" element={<ViewForm />} />
                     </CustomRoutes>
                 </>
             )}

--- a/packages/admin-client/src/Applications/ApplicationList.tsx
+++ b/packages/admin-client/src/Applications/ApplicationList.tsx
@@ -28,7 +28,7 @@ export const ApplicationList = (props: any) => {
     const handleRowClick = (id: Identifier, resource: string, record: any) => {
         // In admin client, applications are never in draft.
         if (record.form_submission_id) {
-            redirect("/ViewForm/View/applications/" + record.form_submission_id + "/" + record.id, "")
+            redirect("/ViewForm/applications/" + record.id, "")
         } else {
             return "" // rowClick expects a path to be returned
         }

--- a/packages/admin-client/src/Claims/ClaimList.tsx
+++ b/packages/admin-client/src/Claims/ClaimList.tsx
@@ -27,12 +27,7 @@ export const ClaimList = (props: any) => {
 
     const handleRowClick = (id: Identifier, resource: string, record: any) => {
         if (record.service_provider_form_submission_id) {
-            //TODO: cancelled status
-            if (record.status === "In Progress") {
-                redirect("/ViewForm/Draft/claims/" + record.service_provider_form_submission_id + "/" + record.id, "")
-            } else {
-                redirect("/ViewForm/View/claims/" + record.service_provider_form_submission_id + "/" + record.id, "")
-            }
+            redirect("/ViewForm/claims/" + record.id, "")
         } else {
             return "" // rowClick expects a path to be returned
         }

--- a/packages/admin-client/src/common/components/CalculatorButtonField/CalculatorButtonField.tsx
+++ b/packages/admin-client/src/common/components/CalculatorButtonField/CalculatorButtonField.tsx
@@ -12,13 +12,7 @@ const CalculatorButtonField: React.FC = () => {
         <Button
             onClick={(event) => {
                 event?.stopPropagation()
-                redirect(
-                    `/ViewForm/Draft/claims/${record.service_provider_form_submission_id}/${record.id}`,
-                    "",
-                    "",
-                    {},
-                    { initialTab: "calculator" }
-                )
+                redirect(`/ViewForm/claims/${record.id}`, "", "", {}, { initialTab: "calculator" })
             }}
             sx={{ minWidth: "2.5em" }}
             aria-label="Open calculator"


### PR DESCRIPTION
This pull request fixes a bug where the embedded form and new-tab form would sometimes display in the wrong editing mode for the current status. The embedded and new-tab forms should now always display in the correct editing status corresponding to the current form status and user account type. Changes are as follows:

- [x] Do not pass form record fields through form screen URL unnecessarily. Instead, extract them from the record obtained on form screen.
- [x] Whenever form record changes, construct form URL according to the current resource, record status, and user identity provider.
- [x] Make embedded form and new tab form depend on constructed form URL, not on page URL, so editing mode of embedded and new-tab forms always correspond to current status.