### PR TITLE
TECH-524, TECH-525, TECH-526: Fix Shared With column, list aside alignment

### DIFF
--- a/packages/employer-api/src/services/application.service.ts
+++ b/packages/employer-api/src/services/application.service.ts
@@ -16,7 +16,8 @@ export const getAllApplications = async (
         .whereIn("a.id", applicationIds)
         .select("a.*")
         .groupBy("a.id")
-        .select(knex.raw("ARRAY_AGG(e.contact_name) as shared_with"))
+        // Compute 'Shared With' column. Do not include the name of the requestor, and do not include NULL in its place.
+        .select(knex.raw("COALESCE( ARRAY_AGG(e.contact_name) FILTER (WHERE e.id!=?), '{}') as shared_with", user))
         .modify((queryBuilder: any) => {
             if (filters.id) {
                 queryBuilder.where("id", filters.id)

--- a/packages/employer-api/src/services/claim.service.ts
+++ b/packages/employer-api/src/services/claim.service.ts
@@ -16,7 +16,7 @@ export const getAllClaims = async (
         .whereIn("c.id", claimIds)
         .select("c.*")
         .groupBy("c.id")
-        .select(knex.raw("ARRAY_AGG(e.contact_name) as shared_with"))
+        .select(knex.raw("COALESCE( ARRAY_AGG(e.contact_name) FILTER (WHERE e.id!=?), '{}') as shared_with", user))
         .modify((queryBuilder: any) => {
             if (filters.id) {
                 queryBuilder.where("id", filters.id)

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -1,11 +1,13 @@
 import { Box, Chip } from "@mui/material"
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { FunctionField, Identifier, List, TextField, useGetIdentity, useRedirect } from "react-admin"
 import CustomDatagrid from "../common/components/CustomDatagrid/CustomDatagrid"
 import { FormBulkActionButtons } from "../common/components/FormBulkActionButtons/FormBulkActionButtons"
 import { ListActions } from "../common/components/ListActions/ListActions"
 import { ListAside } from "../common/components/ListAside/ListAside"
 import { DatagridStyles } from "../common/styles/DatagridStyles"
+import { SharedWithModal } from "../common/components/SharedWithField/SharedWithModal"
+import { SharedWithField } from "../common/components/SharedWithField/SharedWithField"
 
 export const claimStatusFilters = {
     All: { label: "All" },
@@ -18,6 +20,9 @@ export const ClaimList = (props: any) => {
     const [statusFilter, setStatusFilter] = useState(claimStatusFilters["All"])
     const { identity } = useGetIdentity()
     const redirect = useRedirect()
+    const [modalIsOpen, setModalIsOpen] = useState(false)
+    const [sharedUsers, setSharedUsers] = useState([])
+    const [sharedFormId, setSharedFormId] = useState("")
 
     const handleRowClick = (id: Identifier, resource: string, record: any) => {
         if (record.status === "Draft" && record.form_submission_id) {
@@ -29,97 +34,114 @@ export const ClaimList = (props: any) => {
         }
     }
 
+    const openModal = useCallback((formId, sharedUsers) => {
+        setSharedFormId(formId)
+        setSharedUsers(sharedUsers)
+        setModalIsOpen(true)
+    }, [])
+
+    const closeModal = useCallback(() => {
+        setSharedFormId("")
+        setSharedUsers([])
+        setModalIsOpen(false)
+    }, [])
+
     return (
         <>
             {identity !== undefined && (
-                <Box id="main-content-custom" tabIndex={0} aria-label="main content">
-                    <List
-                        {...props}
-                        actions={<ListActions createButtonLabel="New Claim Form" />}
-                        filter={{ ...statusFilter, user: identity.guid }}
-                        filterDefaultValues={{ ...statusFilter, user: identity.guid }}
-                        aside={
-                            <ListAside
-                                statusFilters={claimStatusFilters}
-                                statusFilter={statusFilter}
-                                setStatusFilter={setStatusFilter}
-                                user={identity.guid}
-                            />
-                        }
-                        sort={{
-                            field: "form_submitted_date,updated_date,created_date",
-                            order: "DESC,DESC,DESC"
-                        }}
-                    >
-                        <CustomDatagrid
-                            bulkActionButtons={<FormBulkActionButtons />}
-                            sx={DatagridStyles}
-                            rowClick={handleRowClick}
-                            ariaLabel="claims list"
+                <>
+                    <Box id="main-content-custom" tabIndex={0} aria-label="main content">
+                        <List
+                            {...props}
+                            actions={<ListActions createButtonLabel="New Claim Form" />}
+                            filter={{ ...statusFilter, user: identity.guid }}
+                            filterDefaultValues={{ ...statusFilter, user: identity.guid }}
+                            aside={
+                                <ListAside
+                                    statusFilters={claimStatusFilters}
+                                    statusFilter={statusFilter}
+                                    setStatusFilter={setStatusFilter}
+                                    user={identity.guid}
+                                />
+                            }
+                            sort={{
+                                field: "form_submitted_date,updated_date,created_date",
+                                order: "DESC,DESC,DESC"
+                            }}
                         >
-                            <TextField label="Submission ID" source="form_confirmation_id" emptyText="-" />
-                            <TextField label="Position Title" source="position_title" emptyText="-" />
-                            <FunctionField
-                                label="Employee Name"
-                                render={(record: any) =>
-                                    record.employee_first_name || record.employee_last_name
-                                        ? `${record.employee_first_name ?? ""} ${record.employee_last_name ?? ""}`
-                                        : "-"
-                                }
-                            />
-                            <FunctionField
-                                label="Submitted Date"
-                                render={
-                                    (record: any) =>
-                                        record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp
-                                }
-                            />
-                            <FunctionField
-                                label="Shared With"
-                                render={(record: any) => {
-                                    return record["shared_with"].length > 1
-                                        ? record["shared_with"].filter((fullName) => fullName !== identity?.fullName)
-                                        : "-"
-                                }}
-                            />
-                            <TextField
-                                label="Associated Application ID"
-                                source="associated_application_id"
-                                emptyText="-"
-                            />
-                            <FunctionField
-                                label={
-                                    <Box display="flex" width="100%" justifyContent="center">
-                                        Status
-                                    </Box>
-                                }
-                                render={(record: any) => (
-                                    <Box display="flex" width="100%" justifyContent="center">
-                                        <Chip
-                                            label={
-                                                record.status === "New" ||
-                                                record.status === "In Progress" ||
-                                                record.status === "Completed"
-                                                    ? "Submitted"
-                                                    : record.status
-                                            }
-                                            size="small"
-                                            color={
-                                                record.status === "New" ||
-                                                record.status === "In Progress" ||
-                                                record.status === "Completed"
-                                                    ? "info"
-                                                    : record.status === "Cancelled"
-                                                    ? "error"
-                                                    : "secondary"
-                                            }
-                                        />
-                                    </Box>
-                                )}
-                            />
-                        </CustomDatagrid>
-                    </List>
-                </Box>
+                            <CustomDatagrid
+                                bulkActionButtons={<FormBulkActionButtons />}
+                                sx={DatagridStyles}
+                                rowClick={handleRowClick}
+                                ariaLabel="claims list"
+                            >
+                                <TextField label="Submission ID" source="form_confirmation_id" emptyText="-" />
+                                <TextField label="Position Title" source="position_title" emptyText="-" />
+                                <FunctionField
+                                    label="Employee Name"
+                                    render={(record: any) =>
+                                        record.employee_first_name || record.employee_last_name
+                                            ? `${record.employee_first_name ?? ""} ${record.employee_last_name ?? ""}`
+                                            : "-"
+                                    }
+                                />
+                                <FunctionField
+                                    label="Submitted Date"
+                                    render={
+                                        (record: any) =>
+                                            record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp
+                                    }
+                                />
+                                <TextField
+                                    label="Associated Application ID"
+                                    source="associated_application_id"
+                                    emptyText="-"
+                                />
+                                <SharedWithField label="Shared With" openModal={openModal} />
+                                <FunctionField
+                                    label={
+                                        <Box display="flex" width="100%" justifyContent="center">
+                                            Status
+                                        </Box>
+                                    }
+                                    render={(record: any) => (
+                                        <Box display="flex" width="100%" justifyContent="center">
+                                            <Chip
+                                                label={
+                                                    record.status === "New" ||
+                                                    record.status === "In Progress" ||
+                                                    record.status === "Completed"
+                                                        ? "Submitted"
+                                                        : record.status
+                                                }
+                                                size="small"
+                                                color={
+                                                    record.status === "New" ||
+                                                    record.status === "In Progress" ||
+                                                    record.status === "Completed"
+                                                        ? "info"
+                                                        : record.status === "Cancelled"
+                                                        ? "error"
+                                                        : "secondary"
+                                                }
+                                            />
+                                        </Box>
+                                    )}
+                                />
+                            </CustomDatagrid>
+                        </List>
+                    </Box>
+                    <Box>
+                        <SharedWithModal
+                            isOpen={modalIsOpen}
+                            onRequestClose={closeModal}
+                            contentLabel="shared users"
+                            formId={sharedFormId}
+                            sharedUsers={sharedUsers}
+                            resource="claims"
+                        />
+                    </Box>
+                </>
             )}
         </>
     )

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -80,19 +80,19 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
     }, [])
 
     return (
-        <Box width={200} mr={1} mt={7} flexShrink={0} order={-1} style={{ transform: "translate(0em, -1.85em)" }}>
-            <Box
-                // width="11em"
-                style={{
-                    color: "#307FE2",
-                    padding: "0em 0.5em 0.0em 0.5em",
-                    borderBottom: "3px solid #307FE2",
-                    marginBottom: "0px",
-                    cursor: "default",
-                    fontSize: "18px"
-                }}
-            >
-                <span className="catchment-label" aria-hidden={true}>
+        <Box width={200} mr={1} mt={7} flexShrink={0} order={-1} style={{ transform: "translate(0em, -1.7em)" }}>
+            <Box style={{ transform: "translate(0em, -0.5em)" }}>
+                <span
+                    style={{
+                        color: "#307FE2",
+                        padding: "0em 0.5em 0.45em 0.5em",
+                        borderBottom: "3px solid #307FE2",
+                        marginBottom: "4px",
+                        cursor: "default",
+                        fontSize: "18px"
+                    }}
+                    aria-hidden={true}
+                >
                     Status Filter
                 </span>
             </Box>

--- a/packages/employer-client/src/common/components/SharedWithField/SharedWithField.tsx
+++ b/packages/employer-client/src/common/components/SharedWithField/SharedWithField.tsx
@@ -1,0 +1,45 @@
+import { Chip, Tooltip } from "@mui/material"
+import { FunctionField } from "react-admin"
+
+interface SharedWithFieldProps {
+    // Label must be passed as prop for it to be extracted into column header by React Admin.
+    label: string
+    openModal: (formId: any, sharedUsers: any) => void
+}
+
+export const SharedWithField: React.FC<SharedWithFieldProps> = ({ label, openModal }) => {
+    return (
+        <FunctionField
+            label="Shared With"
+            render={(record: any) => {
+                const sortedNames = record["shared_with"].sort((a, b) => a.localeCompare(b))
+                const chipLabel =
+                    sortedNames.length === 0
+                        ? "None"
+                        : sortedNames.length === 1
+                        ? sortedNames
+                        : sortedNames.length === 2
+                        ? sortedNames[0] + ", " + (sortedNames.length - 1) + " other"
+                        : sortedNames[0] + ", " + (sortedNames.length - 1) + " others"
+
+                return (
+                    <div>
+                        {/* To prevent screen reader from reading label as a 'group', only render tooltip if clickable.*/}
+                        {record["shared_with"].length > 1 ? (
+                            <Tooltip title="View all shared users" aria-label={chipLabel + ". View all shared users."}>
+                                <Chip
+                                    label={chipLabel}
+                                    size="small"
+                                    clickable
+                                    onClick={() => openModal(record.form_confirmation_id, sortedNames)}
+                                />
+                            </Tooltip>
+                        ) : (
+                            <Chip label={chipLabel} size="small" />
+                        )}
+                    </div>
+                )
+            }}
+        />
+    )
+}

--- a/packages/employer-client/src/common/components/SharedWithField/SharedWithModal.tsx
+++ b/packages/employer-client/src/common/components/SharedWithField/SharedWithModal.tsx
@@ -1,0 +1,47 @@
+import { Box, List, ListItem } from "@mui/material"
+import BCGovModal from "../BCGovModal/BCGovModal"
+import { COLOURS } from "../../../Colours"
+import ModalButton from "../BCGovModal/BCGovModalButton"
+
+interface SharedWithModalProps {
+    isOpen: boolean
+    onRequestClose: (event: any) => void
+    contentLabel: string
+    formId: string
+    sharedUsers: string[]
+    resource: string
+}
+
+export const SharedWithModal: React.FC<SharedWithModalProps> = ({
+    isOpen,
+    onRequestClose,
+    contentLabel,
+    formId,
+    sharedUsers,
+    resource
+}) => {
+    return (
+        <BCGovModal isOpen={isOpen} onRequestClose={onRequestClose} contentLabel={contentLabel}>
+            <Box>
+                <h4>
+                    {resource === "applications" ? "Application" : "Claim"} {formId} is shared with:
+                </h4>
+                <List
+                    style={{
+                        minHeight: "5em",
+                        maxHeight: "20em",
+                        overflow: "auto",
+                        border: "2px solid " + COLOURS.MEDIUMGREY
+                    }}
+                >
+                    {sharedUsers.map((user) => (
+                        <ListItem key={user}>{user}</ListItem>
+                    ))}
+                </List>
+            </Box>
+            <Box width="100%" textAlign="right" paddingTop="1em">
+                <ModalButton text="OK" showIcon={false} onClick={onRequestClose} ariaLabel="Close dialog" />
+            </Box>
+        </BCGovModal>
+    )
+}


### PR DESCRIPTION
This pull request improves the behaviour and usability of the Shared With column. It also attempts to fix a styling issue in the employer client where the list aside was misaligned with the list. Changes are as follows:

TECH-524:
- [x] Fix bug: do not include name of current user in Shared With column in list query result.
- [x] Do not filter contents of Shared With column, since the list query now returns the desired data directly.

TECH-525:
- [x] Implement modal to display list of users who share a form.
- [x] Implement custom list field SharedWithField for the Shared With column; clicking the field opens a modal displaying the list of shared users when there are 2 or more shared users; the field indicates the number of shared users.
- [x] Render the Shared With column as Chips to visually demarcate metadata from form data, similar to Status column.

TECH-526:
- [x] Attempt fix: vertically align list aside with list in employer client. Use same styling parameters that are currently working in admin client