### PR TITLE
TECH-548: Do not pass guids through list query endpoint URLs

### DIFF
--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -55,14 +55,13 @@ export const ApplicationList = (props: any) => {
                         <List
                             {...props}
                             actions={<ListActions createButtonLabel="New Application" />}
-                            filter={{ ...statusFilter, user: identity.guid }}
-                            filterDefaultValues={{ ...statusFilter, user: identity.guid }}
+                            filter={statusFilter}
+                            filterDefaultValues={statusFilter}
                             aside={
                                 <ListAside
                                     statusFilters={applicationStatusFilters}
                                     statusFilter={statusFilter}
                                     setStatusFilter={setStatusFilter}
-                                    user={identity.guid}
                                 />
                             }
                             sort={{

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -54,14 +54,13 @@ export const ClaimList = (props: any) => {
                         <List
                             {...props}
                             actions={<ListActions createButtonLabel="New Claim Form" />}
-                            filter={{ ...statusFilter, user: identity.guid }}
-                            filterDefaultValues={{ ...statusFilter, user: identity.guid }}
+                            filter={statusFilter}
+                            filterDefaultValues={statusFilter}
                             aside={
                                 <ListAside
                                     statusFilters={claimStatusFilters}
                                     statusFilter={statusFilter}
                                     setStatusFilter={setStatusFilter}
-                                    user={identity.guid}
                                 />
                             }
                             sort={{

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -1,5 +1,5 @@
 import { Box, ListItemText, MenuItem, MenuList } from "@mui/material"
-import { LoadingIndicator, useDataProvider, useListContext, useRedirect } from "react-admin"
+import { useDataProvider, useListContext, useRedirect } from "react-admin"
 import isEqual from "lodash/isEqual"
 import { ScreenReaderOnly } from "../../styles/ScreenReaderOnly"
 import { useEffect, useState } from "react"
@@ -9,10 +9,9 @@ interface ListAsideProps {
     statusFilters: { [key: string]: any }
     statusFilter: any
     setStatusFilter: React.Dispatch<any>
-    user: string
 }
 
-export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilter, setStatusFilter, user }) => {
+export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilter, setStatusFilter }) => {
     const { resource, total, isFetching } = useListContext()
     const dataProvider = useDataProvider()
     const redirect = useRedirect()


### PR DESCRIPTION
This pull request prevents guids from being passed through the URLs for list query endpoints. This was happening because the guid was part of the default list filter, and the list filter is passed to the API as a set of query parameters. We can remove the guid from the list filter and use the guid from the token instead, similar to other endpoints. Changes are as follows:

- [x] Remove unused user field from list filters.
- [x] Remove unused user prop from ListAside.