### PR TITLE
TECH-547: Employer client: internal server error after every form submission

### DIFF
--- a/packages/employer-api/src/controllers/event.controller.ts
+++ b/packages/employer-api/src/controllers/event.controller.ts
@@ -66,8 +66,11 @@ export const submission = async (req: any, res: express.Response) => {
                     }
                     // Send notifications to clients with Claims notifications enabled
                     const sendNotificationsResult = await formApiService.sendNotifications({
-                        catchmentNo: newSPClaim.catchmentno,
-                        applicationType: "Claims"
+                        // form API expects the data to be wrapped in a data object
+                        data: {
+                            catchmentNo: newSPClaim.catchmentno,
+                            applicationType: "Claims"
+                        }
                     })
                     if (sendNotificationsResult.status !== 200) {
                         console.log("Error sending notifications")

--- a/packages/form-api/src/controllers/email.controller.ts
+++ b/packages/form-api/src/controllers/email.controller.ts
@@ -79,7 +79,7 @@ export const sendEmail = async (req: express.Request, res: express.Response) => 
                 notificationList.map(async (notification: Notification) => {
                     await emailService.sendEmail(
                         notificationHTML,
-                        `New Wage Subsidy ${String(applicationType) === "Claims" ? "Claim" : ""} Application Submitted`,
+                        `New Wage Subsidy${String(applicationType) === "Claims" ? " Claim" : ""} Application Submitted`,
                         [notification.email]
                     )
                 })

--- a/packages/form-api/src/controllers/email.controller.ts
+++ b/packages/form-api/src/controllers/email.controller.ts
@@ -79,9 +79,7 @@ export const sendEmail = async (req: express.Request, res: express.Response) => 
                 notificationList.map(async (notification: Notification) => {
                     await emailService.sendEmail(
                         notificationHTML,
-                        `New Wage Subsidy ${
-                            String(applicationType) === "Claims" ? "Claims" : ""
-                        } Application Submitted`,
+                        `New Wage Subsidy ${String(applicationType) === "Claims" ? "Claim" : ""} Application Submitted`,
                         [notification.email]
                     )
                 })

--- a/packages/form-api/src/templates/notification.template.ts
+++ b/packages/form-api/src/templates/notification.template.ts
@@ -5,11 +5,11 @@ const applicationNotification = (catchmentNo: string, catchmentName: string, typ
     const claimsUrl = `${process.env.SP_URL}/#/claims`
     const applicationsUrl = `${process.env.SP_URL}/#/applications`
     const email = generateHTMLEmail(
-        "A Wage Subsidy Claim Application has been submitted",
+        `A Wage Subsidy${type === "claim" ? " Claim" : ""} Application has been submitted`,
         [
             ` Hello `,
-            ` You are receiving this email because you enabled notifications on Wage Subsidy ${
-                type === "claim" ? "Claim" : ""
+            ` You are receiving this email because you enabled notifications on Wage Subsidy${
+                type === "claim" ? " Claim" : ""
             } Applications for Catchment ${catchmentNo} - ${catchmentName}.`
         ],
         [


### PR DESCRIPTION
Cause:
- email controller was reading applicationType and catchmentNo off of the data object.

Description of changes:
- Wrapped post object to form API in data.
- Fixed spacing issues, typos on notification email title

Working current when I send a postman request to the endpoint with my own tokens.