### PR TITLE
TECH-546, TECH-554: Support custom sorting by date, remove checkboxes from SelectApplication list

### DIFF
--- a/packages/admin-api/src/controllers/application.controller.ts
+++ b/packages/admin-api/src/controllers/application.controller.ts
@@ -26,7 +26,7 @@ export const getAllApplications = async (req: any, res: express.Response) => {
         }
         const sort: string[] = req.query.sort ? JSON.parse(req.query.sort) : []
         const sortFields = sort?.length > 0 ? sort[0].split(",") : []
-        const sortOrders = sort?.length > 0 ? sort[1].split(",") : []
+        const sortOrder = sort?.length > 1 ? sort[1] : ""
         const page = req.query.page ?? 1
         const perPage = req.query.perPage ?? 1
         const applications = await applicationService.getAllApplications(
@@ -34,7 +34,7 @@ export const getAllApplications = async (req: any, res: express.Response) => {
             Number(page),
             filter,
             sortFields,
-            sortOrders
+            sortOrder
         )
 
         // TODO: synchronize DB with CHEFS forms as necessary.

--- a/packages/admin-api/src/controllers/claim.controller.ts
+++ b/packages/admin-api/src/controllers/claim.controller.ts
@@ -30,10 +30,10 @@ export const getAllClaims = async (req: any, res: express.Response) => {
         }
         const sort: string[] = req.query.sort ? JSON.parse(req.query.sort) : []
         const sortFields = sort?.length > 0 ? sort[0].split(",") : []
-        const sortOrders = sort?.length > 0 ? sort[1].split(",") : []
+        const sortOrder = sort?.length > 1 ? sort[1] : ""
         const page = req.query.page ?? 1
         const perPage = req.query.perPage ?? 1
-        const claims = await claimService.getAllClaims(Number(perPage), Number(page), filter, sortFields, sortOrders)
+        const claims = await claimService.getAllClaims(Number(perPage), Number(page), filter, sortFields, sortOrder)
         res.set({
             "Access-Control-Expose-Headers": "Content-Range",
             "Content-Range": `0 - ${claims.pagination.to} / ${claims.pagination.total}`

--- a/packages/admin-api/src/lib/transactions.ts
+++ b/packages/admin-api/src/lib/transactions.ts
@@ -10,13 +10,13 @@ const PAGE = 1
 
 const getAssociatedApplication = async (claim: any, trx: any) => {
     const filter = { form_confirmation_id: claim.associated_application_id }
-    return applicationService.getAllApplications(MAX_RESULTS, PAGE, filter, [], [], trx)
+    return applicationService.getAllApplications(MAX_RESULTS, PAGE, filter, [], "", trx)
 }
 
 const getAssociatedClaims = async (application: any, trx: any) => {
     const filter = { associated_application_id: application.form_confirmation_id }
     const getDrafts = false
-    return claimService.getAllClaims(MAX_RESULTS, PAGE, filter, [], [], getDrafts, trx)
+    return claimService.getAllClaims(MAX_RESULTS, PAGE, filter, [], "", getDrafts, trx)
 }
 
 const updateAssociatedClaims = async (application: any, data: any, username: string, trx: any) => {

--- a/packages/admin-api/src/services/application.service.ts
+++ b/packages/admin-api/src/services/application.service.ts
@@ -6,7 +6,7 @@ export const getAllApplications = async (
     currPage: number,
     filters: any,
     sortFields: string[],
-    sortOrders: string[],
+    sortOrder: string,
     trx?: any
 ) => {
     const applications = await knex("applications")
@@ -24,9 +24,11 @@ export const getAllApplications = async (
             if (filters.form_confirmation_id) {
                 queryBuilder.where("form_confirmation_id", filters.form_confirmation_id)
             }
-            if (sortFields?.length > 0 && sortOrders?.length > 0) {
+            if (sortFields?.length > 0 && sortOrder) {
                 sortFields.forEach((field, i) => {
-                    queryBuilder.orderByRaw(`${field} ${sortOrders[i]} NULLS LAST`)
+                    sortOrder === "DESC"
+                        ? queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS LAST`)
+                        : queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS FIRST`)
                 })
             } else {
                 // default sort

--- a/packages/admin-api/src/services/claims.service.ts
+++ b/packages/admin-api/src/services/claims.service.ts
@@ -9,7 +9,7 @@ export const getAllClaims = async (
     currPage: number,
     filters: any,
     sortFields: string[],
-    sortOrders: string[],
+    sortOrder: string,
     getDrafts?: boolean,
     trx?: any
 ) => {
@@ -30,9 +30,11 @@ export const getAllClaims = async (
             if (filters.associated_application_id) {
                 queryBuilder.where("associated_application_id", filters.associated_application_id)
             }
-            if (sortFields?.length > 0 && sortOrders?.length > 0) {
+            if (sortFields?.length > 0 && sortOrder) {
                 sortFields.forEach((field, i) => {
-                    queryBuilder.orderByRaw(`${field} ${sortOrders[i]} NULLS LAST`)
+                    sortOrder === "DESC"
+                        ? queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS LAST`)
+                        : queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS FIRST`)
                 })
             } else {
                 // default sort

--- a/packages/admin-client/src/Applications/ApplicationList.tsx
+++ b/packages/admin-client/src/Applications/ApplicationList.tsx
@@ -53,7 +53,7 @@ export const ApplicationList = (props: any) => {
                         }
                         sort={{
                             field: "form_submitted_date,updated_date,created_date",
-                            order: "DESC,DESC,DESC"
+                            order: "DESC"
                         }}
                     >
                         <CustomDatagrid rowClick={handleRowClick} ariaLabel="applications list">
@@ -62,6 +62,8 @@ export const ApplicationList = (props: any) => {
                             <TextField label="Position Title" source="position_title" emptyText="-" />
                             <FunctionField
                                 label="Submitted Date"
+                                sortBy="form_submitted_date,updated_date,created_date"
+                                sortByOrder="DESC"
                                 render={
                                     (record: any) =>
                                         record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp

--- a/packages/admin-client/src/Claims/ClaimList.tsx
+++ b/packages/admin-client/src/Claims/ClaimList.tsx
@@ -52,7 +52,7 @@ export const ClaimList = (props: any) => {
                         }
                         sort={{
                             field: "form_submitted_date,updated_date,created_date",
-                            order: "DESC,DESC,DESC"
+                            order: "DESC"
                         }}
                     >
                         <CustomDatagrid showCalculatorButton={true} rowClick={handleRowClick} ariaLabel="claims list">
@@ -68,6 +68,8 @@ export const ClaimList = (props: any) => {
                             />
                             <FunctionField
                                 label="Submitted Date"
+                                sortBy="form_submitted_date,updated_date,created_date"
+                                sortByOrder="DESC"
                                 render={
                                     (record: any) =>
                                         record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp

--- a/packages/employer-api/src/controllers/application.controller.ts
+++ b/packages/employer-api/src/controllers/application.controller.ts
@@ -16,7 +16,7 @@ export const getAllApplications = async (req: any, res: express.Response) => {
         const filter = req.query.filter ? JSON.parse(req.query.filter) : {}
         const sort: string[] = req.query.sort ? JSON.parse(req.query.sort) : []
         const sortFields = sort?.length > 0 ? sort[0].split(",") : []
-        const sortOrders = sort?.length > 0 ? sort[1].split(",") : []
+        const sortOrder = sort?.length > 1 ? sort[1] : ""
         const page = req.query.page ?? 1
         const perPage = req.query.perPage ?? 1
         const applications = await applicationService.getAllApplications(
@@ -24,7 +24,7 @@ export const getAllApplications = async (req: any, res: express.Response) => {
             Number(page),
             filter,
             sortFields,
-            sortOrders,
+            sortOrder,
             bceid_guid
         )
         // create a new list of applications with updated status
@@ -38,7 +38,7 @@ export const getAllApplications = async (req: any, res: express.Response) => {
                 Number(page),
                 filter,
                 sortFields,
-                sortOrders,
+                sortOrder,
                 bceid_guid
             )
             // If the user just submitted their first application, update their profile from the application data.

--- a/packages/employer-api/src/controllers/claim.controller.ts
+++ b/packages/employer-api/src/controllers/claim.controller.ts
@@ -17,7 +17,7 @@ export const getAllClaims = async (req: any, res: express.Response) => {
         const filter = req.query.filter ? JSON.parse(req.query.filter) : {}
         const sort: string[] = req.query.sort ? JSON.parse(req.query.sort) : []
         const sortFields = sort?.length > 0 ? sort[0].split(",") : []
-        const sortOrders = sort?.length > 0 ? sort[1].split(",") : []
+        const sortOrder = sort?.length > 1 ? sort[1] : ""
         const page = req.query.page ?? 1
         const perPage = req.query.perPage ?? 1
         const claims = await claimService.getAllClaims(
@@ -25,7 +25,7 @@ export const getAllClaims = async (req: any, res: express.Response) => {
             Number(page),
             filter,
             sortFields,
-            sortOrders,
+            sortOrder,
             bceid_guid
         )
 
@@ -40,7 +40,7 @@ export const getAllClaims = async (req: any, res: express.Response) => {
                 Number(page),
                 filter,
                 sortFields,
-                sortOrders,
+                sortOrder,
                 bceid_guid
             )
         }

--- a/packages/employer-api/src/services/application.service.ts
+++ b/packages/employer-api/src/services/application.service.ts
@@ -6,7 +6,7 @@ export const getAllApplications = async (
     currPage: number,
     filters: any,
     sortFields: string[],
-    sortOrders: string[],
+    sortOrder: string,
     user: string
 ) => {
     const applicationIds = knex("employers_applications").select("application_id").where("employer_id", user)
@@ -28,9 +28,11 @@ export const getAllApplications = async (
             if (filters.form_confirmation_id) {
                 queryBuilder.where("form_confirmation_id", filters.form_confirmation_id)
             }
-            if (sortFields?.length > 0 && sortOrders?.length > 0) {
+            if (sortFields?.length > 0 && sortOrder) {
                 sortFields.forEach((field, i) => {
-                    queryBuilder.orderByRaw(`${field} ${sortOrders[i]} NULLS LAST`)
+                    sortOrder === "DESC"
+                        ? queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS LAST`)
+                        : queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS FIRST`)
                 })
             } else {
                 // default sort

--- a/packages/employer-api/src/services/claim.service.ts
+++ b/packages/employer-api/src/services/claim.service.ts
@@ -6,7 +6,7 @@ export const getAllClaims = async (
     currPage: number,
     filters: any,
     sortFields: string[],
-    sortOrders: string[],
+    sortOrder: string,
     user: string
 ) => {
     const claimIds = knex("employers_claims").select("claim_id").where("employer_id", user)
@@ -27,9 +27,11 @@ export const getAllClaims = async (
             if (filters.catchmentno) {
                 queryBuilder.where("catchmentno", Number(filters.catchmentno))
             }
-            if (sortFields?.length > 0 && sortOrders?.length > 0) {
+            if (sortFields?.length > 0 && sortOrder) {
                 sortFields.forEach((field, i) => {
-                    queryBuilder.orderByRaw(`${field} ${sortOrders[i]} NULLS LAST`)
+                    sortOrder === "DESC"
+                        ? queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS LAST`)
+                        : queryBuilder.orderByRaw(`${field} ${sortOrder} NULLS FIRST`)
                 })
             } else {
                 // default sort

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -71,7 +71,7 @@ export const ApplicationList = (props: any) => {
                             }
                             sort={{
                                 field: "form_submitted_date,updated_date,created_date",
-                                order: "DESC,DESC,DESC"
+                                order: "DESC"
                             }}
                         >
                             <CustomDatagrid sx={DatagridStyles} rowClick={handleRowClick} ariaLabel="applications list">
@@ -80,6 +80,8 @@ export const ApplicationList = (props: any) => {
                                 <TextField label="Number of Positions" source="num_positions" emptyText="-" />{" "}
                                 <FunctionField
                                     label="Submitted Date"
+                                    sortBy="form_submitted_date,updated_date,created_date"
+                                    sortByOrder="DESC"
                                     render={
                                         (record: any) =>
                                             record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp

--- a/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
@@ -72,9 +72,9 @@ export const ClaimCreateSelectApplication = (props: any) => {
                     <CustomDatagrid
                         sx={DatagridStyles}
                         rowClick={handleClick}
-                        bulkActionButtons={false}
                         ariaLabel="list of completed applications"
                         rowAriaLabel="create a claim form for application"
+                        disableBulkActions={true}
                         empty={
                             <p style={{ padding: "16px" }}>
                                 You must have at least one completed application in order to submit a claim
@@ -86,6 +86,8 @@ export const ClaimCreateSelectApplication = (props: any) => {
                         <TextField label="Number of Positions" source="num_positions" emptyText="-" />{" "}
                         <FunctionField
                             label="Submitted Date"
+                            sortBy="form_submitted_date,updated_date,created_date"
+                            sortByOrder="DESC"
                             render={
                                 (record: any) =>
                                     record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -70,7 +70,7 @@ export const ClaimList = (props: any) => {
                             }
                             sort={{
                                 field: "form_submitted_date,updated_date,created_date",
-                                order: "DESC,DESC,DESC"
+                                order: "DESC"
                             }}
                         >
                             <CustomDatagrid
@@ -91,6 +91,8 @@ export const ClaimList = (props: any) => {
                                 />
                                 <FunctionField
                                     label="Submitted Date"
+                                    sortBy="form_submitted_date,updated_date,created_date"
+                                    sortByOrder="DESC"
                                     render={
                                         (record: any) =>
                                             record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp

--- a/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
+++ b/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
@@ -14,6 +14,7 @@ type CustomDatagridProps<T> = T & {
     ariaLabel: string
     showCalculatorButton?: boolean
     rowAriaLabel?: string
+    disableBulkActions?: boolean
 }
 
 type CustomDatagridBodyProps<T> = T & {
@@ -30,12 +31,20 @@ const CustomDatagridBody = <T,>({ rowAriaLabel, showCalculatorButton, ...props }
     )
 }
 
-const CustomDatagrid = <T,>({ ariaLabel, showCalculatorButton, rowAriaLabel, ...props }: CustomDatagridProps<T>) => {
+const CustomDatagrid = <T,>({
+    ariaLabel,
+    showCalculatorButton,
+    rowAriaLabel,
+    disableBulkActions,
+    ...props
+}: CustomDatagridProps<T>) => {
     const { identity } = useGetIdentity()
     const [hasBulkActions, setHasBulkActions] = useState<boolean>(false)
 
     useEffect(() => {
-        setHasBulkActions(identity && identity.businessGuid && identity.businessName)
+        if (!disableBulkActions) {
+            setHasBulkActions(identity && identity.businessGuid && identity.businessName)
+        }
     }, [identity])
 
     const skipToListAside = (event: any) => {


### PR DESCRIPTION
This pull request allows the user to sort all lists by the default sort order by clicking the Submitted Date column header. It also prevents the SelectApplication list from ever containing checkboxes or a bulk actions menu, since the SelectApplication list is only used to select the associated application when a claim is created. Changes are as follows:

TECH-546:
- [x] Modify sorting logic in backend to support custom multi-column sorts triggered by column headers (limit number of sort orders to one, since list fields support sorting by multiple columns but only a single sort order).
- [x] Implement custom default sorting by Submitted Date column in all lists.

TECH-554:
- [x] Disable checkboxes and form bulk actions menu on the SelectApplication list for all users.