### PR TITLE
TECH-545: remove unsupported catchments from permissions query results

### DIFF
--- a/packages/admin-api/src/services/permission.service.ts
+++ b/packages/admin-api/src/services/permission.service.ts
@@ -17,7 +17,13 @@ export const getPermission = async (guid: string, isIDIR: boolean) => {
                 password: `${process.env.SAM_API_PASSWORD}`
             }
         })
-        .then((response) => response.data.filter((item: any) => item.Application === "WGS"))
+        .then((response) =>
+            response.data.filter(
+                (item: any) =>
+                    // Only support catchments 1 - 45.
+                    item.Application === "WGS" && Number(item.Catchment) > 100 && Number(item.Catchment) < 146
+            )
+        )
         .catch((error) => error)
     return response
 }


### PR DESCRIPTION
This pull request removes unsupported catchments (ie those not in range 1 - 45) from permissions query results, so they do not appear as options in the catchment dropdown.