### PR TITLE
TECH-544: Implement improved sync design

### DIFF
--- a/packages/employer-api/src/config/CREATE_SCRIPTS.sql
+++ b/packages/employer-api/src/config/CREATE_SCRIPTS.sql
@@ -15,6 +15,7 @@ CREATE TABLE IF NOT EXISTS public.applications
     created_date date,
     updated_by character varying(255) COLLATE pg_catalog."default",
     updated_date date,
+    stale boolean,
     CONSTRAINT applications_pkey PRIMARY KEY (id)
 )
 
@@ -43,6 +44,7 @@ CREATE TABLE IF NOT EXISTS public.claims
     created_date date,
     updated_by character varying(255) COLLATE pg_catalog."default",
     updated_date date,
+    stale boolean,
     CONSTRAINT claims_pkey PRIMARY KEY (id)
 )
 

--- a/packages/employer-api/src/controllers/claim.controller.ts
+++ b/packages/employer-api/src/controllers/claim.controller.ts
@@ -29,26 +29,11 @@ export const getAllClaims = async (req: any, res: express.Response) => {
             bceid_guid
         )
 
-        let claimsUpdated = claims
-        // create a new list of applications with updated status
-        if (filter.status == null && perPage > 1) {
-            // only update applications once each call cycle
-            // updates the status of applications that have been submitted or in draft
-            await Promise.all(claims.data.map(updateClaimFromForm))
-            claimsUpdated = await claimService.getAllClaims(
-                Number(perPage),
-                Number(page),
-                filter,
-                sortFields,
-                sortOrder,
-                bceid_guid
-            )
-        }
         res.set({
             "Access-Control-Expose-Headers": "Content-Range",
-            "Content-Range": `0 - ${claimsUpdated.pagination.to} / ${claimsUpdated.pagination.total}`
+            "Content-Range": `0 - ${claims.pagination.to} / ${claims.pagination.total}`
         })
-        return res.status(200).send(claimsUpdated.data)
+        return res.status(200).send(claims.data)
     } catch (e: any) {
         console.log(e?.message)
         return res.status(500).send("Server Error")
@@ -119,7 +104,7 @@ export const createClaim = async (req: any, res: express.Response) => {
             )
             if (insertResult?.rowCount === 1) {
                 // successful insertion
-                return res.status(200).send({ submissionId: createDraftResult.id })
+                return res.status(200).send({ recordId: req.body.formKey })
             }
         } else {
             return res.status(500).send("Internal Server Error")
@@ -144,6 +129,27 @@ export const getOneClaim = async (req: any, res: express.Response) => {
         }
         const claims = await claimService.getClaimByID(id)
         return res.status(200).send(claims)
+    } catch (e: any) {
+        console.log(e?.message)
+        return res.status(500).send("Internal Server Error")
+    }
+}
+
+// Update stale claims with latest data from CHEFS forms.
+export const syncClaims = async (req: any, res: express.Response) => {
+    try {
+        const bceid_guid = req.kauth.grant.access_token.content?.bceid_user_guid
+        if (bceid_guid === undefined) {
+            return res.status(403).send("Not Authorized")
+        }
+        const employer = await employerService.getEmployerByID(bceid_guid)
+        if (!employer) {
+            return res.status(403).send("Forbidden or Not Found")
+        }
+        // Update any drafts that have changed.
+        const drafts = await claimService.getStaleDrafts(bceid_guid)
+        await Promise.all(drafts.map(updateClaimFromForm))
+        return res.status(200).send({})
     } catch (e: any) {
         console.log(e?.message)
         return res.status(500).send("Internal Server Error")
@@ -182,9 +188,51 @@ const updateClaimFromForm = async (employerClaimRecord: any) => {
                 employerClaimRecord.form_submission_id
             )
             if (submissionResponse.submission.draft === true) {
-                await claimService.updateClaim(employerClaimRecord.id, "Draft", submissionResponse.submission)
+                await claimService.updateClaim(employerClaimRecord.id, "Draft", submissionResponse.submission, true)
+            } else if (submissionResponse.submission.draft === false) {
+                console.log("form submitted event")
+                // Create SP claim form.
+                const submission = submissionResponse?.submission?.submission
+                const serviceProviderInternalID = `SPx${submission.data.internalId}` // create a new internal id for the SP form
+                const createDraftResult = await formService.createTeamProtectedDraft(
+                    process.env.SP_CLAIM_FORM_ID as string,
+                    process.env.SP_CLAIM_FORM_PASS as string,
+                    process.env.SP_CLAIM_FORM_VERSION_ID as string,
+                    serviceProviderInternalID,
+                    submission.data
+                )
+                // If SP claim form created, then update DB record.
+                if (createDraftResult?.id && createDraftResult.submission) {
+                    await claimService.addServiceProviderClaim(
+                        submissionResponse,
+                        serviceProviderInternalID,
+                        createDraftResult.id
+                    )
+                    // TODO: send notification.
+                }
+                console.log("SP claim form created")
             }
         }
+    }
+}
+
+// Mark a claim as stale.
+export const markClaim = async (req: any, res: express.Response) => {
+    try {
+        const bceid_guid = req.kauth.grant.access_token.content?.bceid_user_guid
+        if (bceid_guid === undefined) {
+            return res.status(403).send("Not Authorized")
+        }
+        const { id } = req.params
+        const employerClaimRecord = await claimService.getEmployerClaimRecord(bceid_guid, id)
+        if (!employerClaimRecord) {
+            return res.status(403).send("Forbidden or Not Found")
+        }
+        await claimService.markClaim(id)
+        return res.status(200).send({ id })
+    } catch (e: any) {
+        console.log(e?.message)
+        return res.status(500).send("Internal Server Error")
     }
 }
 

--- a/packages/employer-api/src/routes/application.route.ts
+++ b/packages/employer-api/src/routes/application.route.ts
@@ -5,10 +5,12 @@ const router = express.Router()
 
 router.get("/", applicationController.getAllApplications)
 router.get("/counts", applicationController.getApplicationCounts)
-router.post("/", applicationController.createApplication)
 router.get("/:id", applicationController.getOneApplication)
-router.put("/:id", applicationController.updateApplication)
+router.post("/", applicationController.createApplication)
 router.put("/share/:id", applicationController.shareApplication)
+router.put("/mark/:id", applicationController.markApplication)
+router.put("/sync", applicationController.syncApplications)
+router.put("/:id", applicationController.updateApplication)
 router.delete("/:id", applicationController.deleteApplication)
 
 export default router

--- a/packages/employer-api/src/routes/claim.route.ts
+++ b/packages/employer-api/src/routes/claim.route.ts
@@ -7,8 +7,10 @@ router.get("/", claimController.getAllClaims)
 router.get("/counts", claimController.getClaimCounts)
 router.post("/", claimController.createClaim)
 router.get("/:id", claimController.getOneClaim)
-router.put("/:id", claimController.updateClaim)
 router.put("/share/:id", claimController.shareClaim)
+router.put("/mark/:id", claimController.markClaim)
+router.put("/sync", claimController.syncClaims)
+router.put("/:id", claimController.updateClaim)
 router.delete("/:id", claimController.deleteClaim)
 
 export default router

--- a/packages/employer-api/src/services/claim.service.ts
+++ b/packages/employer-api/src/services/claim.service.ts
@@ -88,7 +88,7 @@ export const insertClaim = async (
     return false
 }
 
-export const updateClaim = async (id: number, status: string | null, body: any) => {
+export const updateClaim = async (id: number, status: string | null, body: any, requireStale?: boolean) => {
     const claims = await knex("claims").where("id", id)
     if (claims.length === 0) {
         return 0
@@ -98,6 +98,11 @@ export const updateClaim = async (id: number, status: string | null, body: any) 
         const submitted = body.draft === false
         result = await knex("claims")
             .where("id", id)
+            .modify((queryBuilder: any) => {
+                if (requireStale) {
+                    queryBuilder.where("stale", true)
+                }
+            })
             .update({
                 form_confirmation_id: submitted ? body.confirmationId : null, // only store the confirmation ID when the form has been submitted
                 form_submitted_date: submitted ? body.createdAt : null,
@@ -105,9 +110,15 @@ export const updateClaim = async (id: number, status: string | null, body: any) 
                 employee_last_name: body.submission?.data?.container?.employeeLastName,
                 status,
                 updated_by: "system",
-                updated_date: new Date()
+                updated_date: new Date(),
+                stale: false
             })
     }
+    return result
+}
+
+export const markClaim = async (id: string) => {
+    const result = await knex("claims").update("stale", true).where("id", id).where("status", "Draft")
     return result
 }
 
@@ -130,11 +141,9 @@ export const addServiceProviderClaim = async (
     let result
     try {
         const submission = submissionResponse?.submission?.submission
-        console.log("add SP Claim Submission: ", submission)
         if (!submission?.data?.internalId) {
             return null
         }
-        console.log("EMPLOYER CLAIM INTERNAL ID: ", submission.data.internalId)
         const claims = await knex("claims").where("id", submission.data.internalId)
         if (claims.length === 0) {
             console.log("claim record not found")
@@ -225,4 +234,20 @@ export const insertEmployerClaimRecord = async (employerId: string, claimId: str
         }
     })
     return result
+}
+
+export const getStaleDrafts = async (user: string) => {
+    const drafts = knex
+        .select("id", "form_submission_id", "status")
+        .from(
+            knex
+                .select("*")
+                .from("employers_claims as ec")
+                .where("employer_id", user)
+                .join("claims as c1", "c1.id", "=", "ec.claim_id")
+                .as("c2")
+        )
+        .where("status", "Draft")
+        .where("stale", true)
+    return drafts
 }

--- a/packages/employer-client/src/App.tsx
+++ b/packages/employer-client/src/App.tsx
@@ -251,7 +251,7 @@ const CustomAdminWithKeycloak = () => {
                         <Route path="create/SelectApplication" element={<ClaimCreateSelectApplication />} />
                     </Resource>
                     <CustomRoutes>
-                        <Route path="ViewForm/:urlType/:resource/:formId" element={<ViewForm />} />
+                        <Route path="ViewForm/:resource/:recordId" element={<ViewForm />} />
                     </CustomRoutes>
                 </>
             )}

--- a/packages/employer-client/src/Applications/ApplicationCreate.tsx
+++ b/packages/employer-client/src/Applications/ApplicationCreate.tsx
@@ -24,7 +24,7 @@ export const ApplicationCreate = () => {
                 {
                     onSuccess: (data) => {
                         setLoading(false)
-                        redirect("/ViewForm/Draft/applications/" + data.id, "")
+                        redirect("/ViewForm/applications/" + data.id, "")
                     },
                     onError: () => {
                         setLoading(false)

--- a/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
@@ -31,7 +31,7 @@ export const ClaimCreateSelectApplication = (props: any) => {
                 {
                     onSuccess: (data) => {
                         setLoading(false)
-                        redirect("/ViewForm/Draft/claims/" + data.id, "")
+                        redirect("/ViewForm/claims/" + data.id, "")
                     },
                     onError: () => {
                         setLoading(false)

--- a/packages/employer-client/src/DataProvider/DataProvider.tsx
+++ b/packages/employer-client/src/DataProvider/DataProvider.tsx
@@ -154,7 +154,7 @@ export const dataProvider = {
                 Authorization: `Bearer ${localStorage.getItem("token")}`
             })
         }).then(({ json }) => ({
-            data: { ...params.data, id: json.submissionId }
+            data: { ...params.data, id: json.recordId }
         })),
     createOrUpdate: (resource: any, params: { id: any; data: any }) =>
         httpClient(`${apiUrl}/${resource}/${params.id}`, {
@@ -243,5 +243,23 @@ export const dataProvider = {
             )
         ).then((responses) => ({
             data: responses.map(({ json }) => json.id)
-        }))
+        })),
+    sync: (resource: any) =>
+        httpClient(`${apiUrl}/${resource}/sync`, {
+            method: "PUT",
+            headers: new Headers({
+                Accept: "application/json",
+                Authorization: `Bearer ${localStorage.getItem("token")}`
+            })
+        }).then(({ json }) => ({
+            data: json
+        })),
+    mark: (resource: any, params: { id: any }) =>
+        httpClient(`${apiUrl}/${resource}/mark/${params.id}`, {
+            method: "PUT",
+            headers: new Headers({
+                Accept: "application/json",
+                Authorization: `Bearer ${localStorage.getItem("token")}`
+            })
+        }).then(({ json }) => ({ data: json }))
 }

--- a/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
+++ b/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagrid.tsx
@@ -1,8 +1,9 @@
-import { Datagrid, DatagridBody, useGetIdentity } from "react-admin"
+import { Datagrid, DatagridBody, useGetIdentity, useListContext } from "react-admin"
 import CustomDatagridRow from "./CustomDatagridRow"
 import { CustomDatagridHeader } from "./CustomDatagridHeader"
 import { useEffect, useState } from "react"
 import { FormBulkActionButtons } from "../FormBulkActionButtons/FormBulkActionButtons"
+import { isFormElement } from "react-router-dom/dist/dom"
 
 // CustomDatagrid:
 // - Each row includes a PDF button.
@@ -15,6 +16,7 @@ type CustomDatagridProps<T> = T & {
     showCalculatorButton?: boolean
     rowAriaLabel?: string
     disableBulkActions?: boolean
+    setIsFetching?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 type CustomDatagridBodyProps<T> = T & {
@@ -36,16 +38,25 @@ const CustomDatagrid = <T,>({
     showCalculatorButton,
     rowAriaLabel,
     disableBulkActions,
+    // Optional prop allowing parent to observe fetching state.
+    setIsFetching,
     ...props
 }: CustomDatagridProps<T>) => {
     const { identity } = useGetIdentity()
     const [hasBulkActions, setHasBulkActions] = useState<boolean>(false)
+    const { isFetching } = useListContext()
 
     useEffect(() => {
         if (!disableBulkActions) {
             setHasBulkActions(identity && identity.businessGuid && identity.businessName)
         }
     }, [identity])
+
+    useEffect(() => {
+        if (setIsFetching) {
+            setIsFetching(isFetching)
+        }
+    }, [isFetching])
 
     const skipToListAside = (event: any) => {
         if (event.key === "ArrowLeft" || event.key === "ArrowRight") {


### PR DESCRIPTION
- [x] Add stale flag to forms tables.
- [x] Whenever user views form, mark it as stale.
- [x] Whenever user navigates to list screen, sync their stale records.
- [x] Remove sync and employer backfill from list queries so GET request has no side effects.
- [x] Implement loading indicator on list screens which activates during sync and first list query.
- [x] Implement endpoints for syncing DB records from CHEFS.
- [x] Implement endpoints for marking records as stale.
- [x] Modify update() service functions to support updates conditional on freshness, for use during syncs.
- [x] Only pass resource and record ID thru form screen URL.
- [x] On form screen, obtain form info by obtaining the corresponding DB record.
- [x] During claim syncs, create SP claim form if claim submitted.