### PR TITLE
TECH-599: do not sync until employer record known to exist

### DIFF
--- a/packages/employer-client/src/App.tsx
+++ b/packages/employer-client/src/App.tsx
@@ -18,6 +18,7 @@ import { dataProvider } from "./DataProvider/DataProvider"
 import { ViewForm } from "./Form/ViewForm"
 import Layout from "./Layout"
 import Footer from "./footer"
+import { EmployerProvider } from "./common/contexts/EmployerContext"
 
 const initOptions = {
     url: process.env.REACT_APP_KEYCLOAK_URL || "",
@@ -271,8 +272,10 @@ function App() {
                 onTokenExpired: onTokenExpired
             }}
         >
-            <CustomAdminWithKeycloak />
-            <Footer />
+            <EmployerProvider>
+                <CustomAdminWithKeycloak />
+                <Footer />
+            </EmployerProvider>
         </ReactKeycloakProvider>
     )
 }

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -1,5 +1,5 @@
 import { Box, Chip } from "@mui/material"
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useContext } from "react"
 import {
     FunctionField,
     Identifier,
@@ -16,6 +16,7 @@ import { ListAside } from "../common/components/ListAside/ListAside"
 import { DatagridStyles } from "../common/styles/DatagridStyles"
 import { SharedWithModal } from "../common/components/SharedWithField/SharedWithModal"
 import { SharedWithField } from "../common/components/SharedWithField/SharedWithField"
+import { EmployerContext } from "../common/contexts/EmployerContext"
 
 export const applicationStatusFilters = {
     All: { label: "All" },
@@ -38,6 +39,7 @@ export const ApplicationList = (props: any) => {
     const [synced, setSynced] = useState(false)
     const [isFetching, setIsFetching] = useState(false)
     const [ready, setReady] = useState(false)
+    const ec = useContext(EmployerContext)
 
     const syncApplications = () => {
         dataProvider.sync("applications").then(({ data }) => {
@@ -69,9 +71,6 @@ export const ApplicationList = (props: any) => {
 
     useEffect(() => {
         setAllowSharing(identity && identity.businessGuid && identity.businessName)
-        if (identity && !synced) {
-            syncApplications()
-        }
     }, [identity])
 
     useEffect(() => {
@@ -80,12 +79,18 @@ export const ApplicationList = (props: any) => {
         }
     }, [isFetching])
 
+    useEffect(() => {
+        if (identity && ec.profileExists && !synced) {
+            syncApplications()
+        }
+    }, [identity, ec.profileExists])
+
     return (
         <>
-            {identity !== undefined && (
-                <>
-                    <Box id="main-content-custom" tabIndex={0} aria-label="main content">
-                        {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
+            <Box id="main-content-custom" tabIndex={0} aria-label="main content">
+                {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
+                {identity !== undefined && (
+                    <>
                         {synced && (
                             <Box hidden={!ready}>
                                 <List
@@ -174,20 +179,20 @@ export const ApplicationList = (props: any) => {
                                 </List>
                             </Box>
                         )}
-                    </Box>
-                    {allowSharing && (
-                        <Box>
-                            <SharedWithModal
-                                isOpen={modalIsOpen}
-                                onRequestClose={closeModal}
-                                contentLabel="shared users"
-                                formId={sharedFormId}
-                                sharedUsers={sharedUsers}
-                                resource="applications"
-                            />
-                        </Box>
-                    )}
-                </>
+                    </>
+                )}
+            </Box>
+            {allowSharing && (
+                <Box>
+                    <SharedWithModal
+                        isOpen={modalIsOpen}
+                        onRequestClose={closeModal}
+                        contentLabel="shared users"
+                        formId={sharedFormId}
+                        sharedUsers={sharedUsers}
+                        resource="applications"
+                    />
+                </Box>
             )}
         </>
     )

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -1,5 +1,5 @@
 import { Box, Chip } from "@mui/material"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useContext, useEffect, useState } from "react"
 import {
     FunctionField,
     Identifier,
@@ -16,6 +16,7 @@ import { ListAside } from "../common/components/ListAside/ListAside"
 import { DatagridStyles } from "../common/styles/DatagridStyles"
 import { SharedWithModal } from "../common/components/SharedWithField/SharedWithModal"
 import { SharedWithField } from "../common/components/SharedWithField/SharedWithField"
+import { EmployerContext } from "../common/contexts/EmployerContext"
 
 export const claimStatusFilters = {
     All: { label: "All" },
@@ -36,6 +37,7 @@ export const ClaimList = (props: any) => {
     const [synced, setSynced] = useState(false)
     const [isFetching, setIsFetching] = useState(true)
     const [ready, setReady] = useState(false)
+    const ec = useContext(EmployerContext)
 
     const syncClaims = () => {
         dataProvider.sync("claims").then(({ data }) => {
@@ -67,9 +69,6 @@ export const ClaimList = (props: any) => {
 
     useEffect(() => {
         setAllowSharing(identity && identity.businessGuid && identity.businessName)
-        if (identity && !synced) {
-            syncClaims()
-        }
     }, [identity])
 
     useEffect(() => {
@@ -78,12 +77,18 @@ export const ClaimList = (props: any) => {
         }
     }, [isFetching])
 
+    useEffect(() => {
+        if (identity && ec.profileExists && !synced) {
+            syncClaims()
+        }
+    }, [identity, ec.profileExists])
+
     return (
         <>
-            {identity !== undefined && (
-                <>
-                    <Box id="main-content-custom" tabIndex={0} aria-label="main content">
-                        {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
+            <Box id="main-content-custom" tabIndex={0} aria-label="main content">
+                {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
+                {identity !== undefined && (
+                    <>
                         {synced && (
                             <Box hidden={!ready}>
                                 <List
@@ -172,20 +177,20 @@ export const ClaimList = (props: any) => {
                                 </List>
                             </Box>
                         )}
-                    </Box>
-                    {allowSharing && (
-                        <Box>
-                            <SharedWithModal
-                                isOpen={modalIsOpen}
-                                onRequestClose={closeModal}
-                                contentLabel="shared users"
-                                formId={sharedFormId}
-                                sharedUsers={sharedUsers}
-                                resource="claims"
-                            />
-                        </Box>
-                    )}
-                </>
+                    </>
+                )}
+            </Box>
+            {allowSharing && (
+                <Box>
+                    <SharedWithModal
+                        isOpen={modalIsOpen}
+                        onRequestClose={closeModal}
+                        contentLabel="shared users"
+                        formId={sharedFormId}
+                        sharedUsers={sharedUsers}
+                        resource="claims"
+                    />
+                </Box>
             )}
         </>
     )

--- a/packages/employer-client/src/UserProfileModal.tsx
+++ b/packages/employer-client/src/UserProfileModal.tsx
@@ -11,12 +11,13 @@ import {
     email,
     regex
 } from "react-admin"
-import { useEffect, useState } from "react"
+import { useContext, useEffect, useState } from "react"
 import { Box } from "@mui/system"
 import { Stack } from "@mui/material"
 import StyledTextInput from "./common/components/Forms/Fields/StyledTextInput"
 import StyledSelectInput from "./common/components/Forms/Fields/StyledSelectInput"
 import { useMutation } from "react-query"
+import { EmployerContext } from "./common/contexts/EmployerContext"
 
 const SaveButtonStyles = {
     color: "#307FE2",
@@ -43,10 +44,10 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onRequestCl
     const { identity } = useGetIdentity()
     const dataProvider = useDataProvider()
     const logout = useLogout()
-    const [profileExists, setProfileExists] = useState<boolean>(false)
     const [userProfile, setUserProfile] = useState<any>(null)
     const [create] = useCreate()
     const [loading, setLoading] = useState(false)
+    const ec = useContext(EmployerContext)
 
     // When used in React Admin, useMutation() activates the loading indicator during queries.
     const { mutate: getProfile } = useMutation((userGuid: string) => {
@@ -75,7 +76,7 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onRequestCl
             },
             {
                 onSuccess: () => {
-                    setProfileExists(true)
+                    ec.setEmployerProfileExists(true)
                 },
                 onError: () => {
                     logout()
@@ -90,10 +91,10 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onRequestCl
     }
 
     useEffect(() => {
-        if (isOpen && identity && profileExists) {
+        if (isOpen && identity && ec.profileExists) {
             getProfile(identity.guid)
         }
-    }, [isOpen, profileExists])
+    }, [isOpen, ec.profileExists])
 
     useEffect(() => {
         if (!isOpen) {

--- a/packages/employer-client/src/common/contexts/EmployerContext.tsx
+++ b/packages/employer-client/src/common/contexts/EmployerContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useMemo, useState } from "react"
+
+interface EmployerContextState {
+    profileExists: boolean
+    setEmployerProfileExists: (value: boolean) => void
+}
+
+const EmployerContext = createContext<EmployerContextState>({
+    profileExists: false,
+    setEmployerProfileExists: () => {}
+})
+
+const EmployerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [profileExists, setProfileExists] = useState<boolean>(false)
+
+    const setEmployerProfileExists = (value: boolean) => {
+        setProfileExists(value)
+    }
+
+    // Use memoization to prevent unnecessary re-renders.
+    const valueProp = useMemo(() => ({ profileExists, setEmployerProfileExists }), [profileExists])
+
+    return <EmployerContext.Provider value={valueProp}>{children}</EmployerContext.Provider>
+}
+
+export { EmployerContext, EmployerProvider }


### PR DESCRIPTION
This pull request resolves an issue where when the user logs in for the first time, the sync operation can occur before the employer record exists, causing the sync to fail with code 403. The sync operation is now delayed until the employer record is created or known to exist. This pull request also fixes an issue where on the list screen a delay was sometimes visible before the loading indicator activated. Changes are as follows:

- [x] Implement EmployerContext to share some employer state between UserProfileModal and List components without passing state through many intermediate components.
- [x] When employer profile is created or known to exist, set flag in EmployerContext.
- [x] In List components, do not perform sync until employer record is known to exist.
- [x] In List components, render loading indicator immediately, so no delay is visible before it activates.