### PR TITLE
TECH-610: move employer data backfill into event handler

### DIFF
--- a/packages/employer-api/src/controllers/application.controller.ts
+++ b/packages/employer-api/src/controllers/application.controller.ts
@@ -2,7 +2,6 @@
 /* eslint-disable import/prefer-default-export */
 import * as express from "express"
 import { insertApplication } from "../lib/transactions"
-import * as emailController from "./email.controller"
 import * as applicationService from "../services/application.service"
 import * as employerService from "../services/employer.service"
 import * as formService from "../services/form.service"
@@ -151,7 +150,6 @@ const updateApplicationFromForm = async (application: any) => {
                 console.log("form submitted event")
                 // submitted
                 await applicationService.updateApplication(application.id, "New", submissionResponse.submission, true)
-                await emailController.sendEmail(submissionResponse.submission.submission)
             } else if (submissionResponse.submission.draft === true) {
                 // draft
                 await applicationService.updateApplication(application.id, "Draft", submissionResponse.submission, true)

--- a/packages/employer-api/src/controllers/event.controller.ts
+++ b/packages/employer-api/src/controllers/event.controller.ts
@@ -139,6 +139,7 @@ export const submission = async (req: express.Request, res: express.Response) =>
                         submissionResponse.submission,
                         false
                     )
+                    await emailController.sendEmail(submissionResponse.submission.submission)
                     // If first application submitted, backfill employer profile from form data.
                     const firstApplicationSubmitted = await applicationService.oneApplicationSubmitted(
                         application.created_by

--- a/packages/employer-api/src/services/application.service.ts
+++ b/packages/employer-api/src/services/application.service.ts
@@ -167,8 +167,8 @@ export const insertEmployerApplicationRecord = async (employerId: string, applic
 }
 
 export const getStaleDrafts = async (user: string) => {
-    const drafts = knex
-        .select("id", "form_type", "form_submission_id", "status")
+    const drafts = await knex
+        .select("id", "form_type", "form_submission_id", "status", "created_by")
         .from(
             knex
                 .select("*")
@@ -180,6 +180,21 @@ export const getStaleDrafts = async (user: string) => {
         .where("status", "Draft")
         .where("stale", true)
     return drafts
+}
+
+export const oneApplicationSubmitted = async (user: string) => {
+    const submittedApplications = await knex
+        .select("status")
+        .from(
+            knex
+                .select("*")
+                .from("employers_applications as ea")
+                .where("employer_id", user)
+                .join("applications as a1", "a1.id", "=", "ea.application_id")
+                .as("a2")
+        )
+        .whereNot("status", "Draft")
+    return submittedApplications.length === 1
 }
 
 export const getFormId = (formType: string) => {

--- a/packages/employer-api/src/services/claim.service.ts
+++ b/packages/employer-api/src/services/claim.service.ts
@@ -252,3 +252,8 @@ export const getStaleDrafts = async (user: string) => {
         .where("stale", true)
     return drafts
 }
+
+export const getClaimBySubmissionID = async (submissionId: string) => {
+    const claim = await knex("claims").where("form_submission_id", submissionId)
+    return claim.length > 0 ? claim[0] : null
+}


### PR DESCRIPTION
This pull request re-implements the employer data backfill functionality which was removed from the list queries as part of the new sync design. The employer data backfill now gets triggered in the event controller when the first application submission event is received for the user. This pull request also extends the event handling to trigger DB updates from all draft save or submit events, so DB syncs can occur without the user navigating back to the list after making form changes. Changes:

- [x] Implement service function to check if first application submitted.
- [x] When application submission event received, backfill employer profile with form data.
- [x] When claim save event received, update corresponding DB record.
- [x] Remove redundant getSubmission() call in application event handler.  