### PR TITLE
TECH-582: remove WorkBC Centre from employer profile

### DIFF
--- a/packages/employer-api/src/config/CREATE_SCRIPTS.sql
+++ b/packages/employer-api/src/config/CREATE_SCRIPTS.sql
@@ -72,7 +72,6 @@ CREATE TABLE IF NOT EXISTS public.employers
     workplace_city character varying(255) COLLATE pg_catalog."default",
     workplace_province character varying(255) COLLATE pg_catalog."default",
     workplace_postal_code character varying(255) COLLATE pg_catalog."default",
-    workbc_centre character varying(4) COLLATE pg_catalog."default",
     created_by character varying(255) COLLATE pg_catalog."default",
     created_date date,
     updated_by character varying(255) COLLATE pg_catalog."default",

--- a/packages/employer-api/src/controllers/application.controller.ts
+++ b/packages/employer-api/src/controllers/application.controller.ts
@@ -257,11 +257,6 @@ export const markApplication = async (req: any, res: express.Response) => {
 }
 
 const computeApplicationPrefillFields = (employer: any) => ({
-    ...(employer?.workbc_centre && {
-        areYouCurrentlyWorkingWithAWorkBcCentre: "Yes",
-        catchmentNoStoreFront: employer.workbc_centre
-    }),
-    ...(!employer?.workbc_centre && { areYouCurrentlyWorkingWithAWorkBcCentre: "No" }),
     ...(employer?.bceid_business_name && { operatingName: employer.bceid_business_name }),
     ...(employer?.cra_business_number && { businessNumber: employer.cra_business_number }),
     ...(employer?.street_address && { businessAddress: employer.street_address }),

--- a/packages/employer-api/src/services/employer.service.ts
+++ b/packages/employer-api/src/services/employer.service.ts
@@ -99,9 +99,6 @@ export const updateEmployer = async (userGuid: string, data: any) => {
                 if (data?.workplace_postal_code || data.workplace_postal_code === null) {
                     queryBuilder.update("workplace_postal_code", data.workplace_postal_code)
                 }
-                if (data?.workbc_centre || data.workbc_centre === null) {
-                    queryBuilder.update("workbc_centre", data.workbc_centre)
-                }
             })
     }
     return numUpdated
@@ -124,8 +121,6 @@ export const updateEmployerFromApplicationForm = async (employer: any, appFormDa
         ...(appFormData?.businessCity && !employer?.city && { city: appFormData.businessCity }),
         ...(appFormData?.businessProvince && !employer?.province && { province: appFormData.businessProvince }),
         ...(appFormData?.businessPostal && !employer?.postal_code && { postal_code: appFormData.businessPostal }),
-        ...(appFormData?.catchmentNoStoreFront &&
-            !employer?.workbc_centre && { workbc_centre: appFormData.catchmentNoStoreFront }),
         ...(appFormData.container?.addressAlt &&
             !employer.container?.workplace_street_address && {
                 workplace_street_address: appFormData.container.addressAlt

--- a/packages/employer-client/src/UserProfileModal.tsx
+++ b/packages/employer-client/src/UserProfileModal.tsx
@@ -239,126 +239,15 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({ isOpen, onRequestCl
                                     sx={{ maxWidth: "20em" }}
                                     validate={maxLength(255)}
                                 />
-                                <Stack direction="row" spacing={6}>
-                                    <StyledSelectInput
-                                        source="workbc_centre"
-                                        label="WorkBC Centre"
-                                        sx={{ minWidth: "32em" }}
-                                        choices={[
-                                            { id: "1-1", name: "WorkBC Centre - Campbell River" },
-                                            { id: "1-2", name: "WorkBC Centre - Port Hardy" },
-                                            { id: "2-1", name: "WorkBC Centre - Courtenay" },
-                                            { id: "2-2", name: "WorkBC Centre - Powell River" },
-                                            { id: "3-1", name: "WorkBC Centre - Port Alberni" },
-                                            { id: "3-2", name: "WorkBC Centre - Ucluelet" },
-                                            { id: "3-3", name: "WorkBC Centre - Tofino" },
-                                            { id: "3-4", name: "WorkBC Centre - Parksville" },
-                                            { id: "4-1", name: "WorkBC Centre - Nanaimo" },
-                                            { id: "5-1", name: "WorkBC Centre - Duncan" },
-                                            { id: "5-2", name: "WorkBC Centre - Ladysmith" },
-                                            { id: "6-1", name: "WorkBC Centre - Langford" },
-                                            { id: "6-2", name: "WorkBC Centre - Sooke" },
-                                            { id: "7-1", name: "WorkBC Centre - Victoria - Douglas" },
-                                            { id: "7-2", name: "WorkBC Centre - Victoria - Borden" },
-                                            { id: "8-1", name: "WorkBC Centre - Sidney" },
-                                            { id: "8-2", name: "WorkBC Centre - Salt Spring Island" },
-                                            { id: "9-1", name: "WorkBC Centre - Sechelt" },
-                                            { id: "9-2", name: "WorkBC Centre - Squamish" },
-                                            { id: "10-1", name: "WorkBC Centre - North Vancouver" },
-                                            { id: "11-1", name: "WorkBC Centre - Vancouver - 134 East Hastings" },
-                                            { id: "11-2", name: "WorkBC Centre - Vancouver - Burrard" },
-                                            { id: "11-3", name: "WorkBC Centre - Vancouver - W Pender" },
-                                            { id: "12-1", name: "WorkBC Centre - Vancouver - East 3rd" },
-                                            { id: "12-2", name: "WorkBC Centre - Vancouver - Midtown West" },
-                                            { id: "13-1", name: "WorkBC Centre - Vancouver - Commercial" },
-                                            { id: "14-1", name: "WorkBC Centre - Vancouver - South" },
-                                            { id: "15-1", name: "WorkBC Centre - Richmond - No 5" },
-                                            { id: "15-2", name: "WorkBC Centre - Richmond - Granville Ave" },
-                                            { id: "16-1", name: "WorkBC Centre - Maple Ridge" },
-                                            { id: "17-1", name: "WorkBC Centre - Port Moody" },
-                                            { id: "17-2", name: "WorkBC Centre - Coquitlam" },
-                                            { id: "17-3", name: "WorkBC Centre - Port Coquitlam" },
-                                            { id: "18-1", name: "WorkBC Centre - Delta - 88th" },
-                                            { id: "18-2", name: "WorkBC Centre - Delta - Delta St" },
-                                            { id: "19-1", name: "WorkBC Centre - Surrey - Guildford" },
-                                            { id: "19-2", name: "WorkBC Centre - Surrey - Whalley" },
-                                            { id: "20-1", name: "WorkBC Centre - Surrey - 56 Ave" },
-                                            { id: "21-1", name: "WorkBC Centre - Surrey - Newton" },
-                                            { id: "22-1", name: "WorkBC Centre - Surrey - 152 St" },
-                                            { id: "23-1", name: "WorkBC Centre - Langley" },
-                                            { id: "23-2", name: "WorkBC Centre - Aldergrove" },
-                                            { id: "24-1", name: "WorkBC Centre - Burnaby - Metrotown" },
-                                            { id: "24-2", name: "WorkBC Centre - Burnaby - Brentwood" },
-                                            { id: "24-3", name: "WorkBC Centre - Burnaby - Edmonds" },
-                                            { id: "25-1", name: "WorkBC Centre - New Westminster" },
-                                            { id: "26-1", name: "WorkBC Centre - Mission" },
-                                            { id: "27-1", name: "WorkBC Centre - Abbotsford" },
-                                            { id: "28-1", name: "WorkBC Centre - Chilliwack" },
-                                            { id: "28-2", name: "WorkBC Centre - Hope" },
-                                            { id: "28-3", name: "WorkBC Centre - Agassiz" },
-                                            { id: "29-1", name: "WorkBC Centre - Quesnel" },
-                                            { id: "29-2", name: "WorkBC Centre - Williams Lake" },
-                                            { id: "29-3", name: "WorkBC Centre - 100 Mile House" },
-                                            { id: "29-4", name: "WorkBC Centre - Bella Coola" },
-                                            { id: "30-1", name: "WorkBC Centre - Merritt" },
-                                            { id: "30-2", name: "WorkBC Centre - Lillooet" },
-                                            { id: "30-3", name: "WorkBC Centre - Ashcroft" },
-                                            { id: "31-1", name: "WorkBC Centre - Kamloops - Lansdowne" },
-                                            { id: "31-2", name: "WorkBC Centre - Kamloops - Tranquille" },
-                                            { id: "31-3", name: "WorkBC Centre - Clearwater" },
-                                            { id: "31-4", name: "WorkBC Centre - Barriere" },
-                                            { id: "31-5", name: "WorkBC Centre - Chase" },
-                                            { id: "32-1", name: "WorkBC Centre - Penticton" },
-                                            { id: "32-2", name: "WorkBC Centre - Oliver" },
-                                            { id: "32-3", name: "WorkBC Centre - Princeton" },
-                                            { id: "32-4", name: "WorkBC Centre - Summerland" },
-                                            { id: "33-1", name: "WorkBC Centre - Kelowna" },
-                                            { id: "33-2", name: "WorkBC Centre - West Kelowna" },
-                                            { id: "33-3", name: "WorkBC Centre - Rutland" },
-                                            { id: "34-1", name: "WorkBC Centre - Salmon Arm" },
-                                            { id: "34-2", name: "WorkBC Centre - Sicamous" },
-                                            { id: "34-3", name: "WorkBC Centre - Golden" },
-                                            { id: "34-4", name: "WorkBC Centre - Revelstoke" },
-                                            { id: "35-1", name: "WorkBC Centre - Trail" },
-                                            { id: "35-2", name: "WorkBC Centre - Castlegar" },
-                                            { id: "35-3", name: "WorkBC Centre - Grand Forks" },
-                                            { id: "36-1", name: "WorkBC Centre - Creston" },
-                                            { id: "36-2", name: "WorkBC Centre - Nelson" },
-                                            { id: "36-3", name: "WorkBC Centre - Nakusp" },
-                                            { id: "37-1", name: "WorkBC Centre - Fernie" },
-                                            { id: "37-2", name: "WorkBC Centre - Cranbrook" },
-                                            { id: "37-3", name: "WorkBC Centre - Invermere" },
-                                            { id: "38-1", name: "WorkBC Centre - Vernon" },
-                                            { id: "38-2", name: "WorkBC Centre - Enderby" },
-                                            { id: "39-1", name: "WorkBC Centre - Prince Rupert - Market" },
-                                            { id: "39-2", name: "WorkBC Centre - Masset" },
-                                            { id: "39-3", name: "WorkBC Centre - Queen Charlotte" },
-                                            { id: "40-1", name: "WorkBC Centre - Terrace - 1st Ave" },
-                                            { id: "40-2", name: "WorkBC Centre - Kitimat" },
-                                            { id: "41-1", name: "WorkBC Centre - Smithers" },
-                                            { id: "41-2", name: "WorkBC Centre - Hazelton" },
-                                            { id: "42-1", name: "WorkBC Centre - Vanderhoof" },
-                                            { id: "42-2", name: "WorkBC Centre - Fort St James" },
-                                            { id: "42-3", name: "WorkBC Centre - Burns Lake" },
-                                            { id: "43-1", name: "WorkBC Centre - Valemount" },
-                                            { id: "43-2", name: "WorkBC Centre - Prince George" },
-                                            { id: "43-3", name: "WorkBC Centre - Mackenzie" },
-                                            { id: "44-1", name: "WorkBC Centre - Fort St John" },
-                                            { id: "44-2", name: "WorkBC Centre - Fort Nelson" },
-                                            { id: "45-1", name: "WorkBC Centre - Dawson Creek" },
-                                            { id: "45-2", name: "WorkBC Centre - Chetwynd" }
-                                        ]}
+                                <Box sx={{ width: "100%", display: "flex", justifyContent: "right" }}>
+                                    <SaveButton icon={<span />} alwaysEnable sx={SaveButtonStyles} />
+                                    <ModalButton
+                                        text="CANCEL"
+                                        showIcon={false}
+                                        onClick={onRequestClose}
+                                        ariaLabel="Close dialog"
                                     />
-                                    <Box sx={{ display: "flex", alignItems: "center", height: "3.5em" }}>
-                                        <SaveButton icon={<span />} alwaysEnable sx={SaveButtonStyles} />
-                                        <ModalButton
-                                            text="CANCEL"
-                                            showIcon={false}
-                                            onClick={onRequestClose}
-                                            ariaLabel="Close dialog"
-                                        />
-                                    </Box>
-                                </Stack>
+                                </Box>
                             </Stack>
                         </Stack>
                     </SimpleForm>


### PR DESCRIPTION
This pull request removes the WorkBC Centre from the employer profile. This change prepares for the future change where the WorkBC Centre will always be determined automatically according to the employer address. Changes are as follows:

- [x] Remove workbc centre from employers table.
- [x] Remove workbc centre from prefill operation.
- [x] Remove workbc centre from employer update operation.
- [x] Remove workbc centre from employer data backfill operation.
- [x] Remove workbc centre from edit profile dialog.