### PR TITLE
TECH-553: fix timestamps

### DIFF
--- a/packages/admin-api/src/services/application.service.ts
+++ b/packages/admin-api/src/services/application.service.ts
@@ -65,7 +65,7 @@ export const updateApplication = async (id: string, username: string, data: any,
             .where("id", id)
             .modify((queryBuilder: any) => {
                 queryBuilder.update("updated_by", username)
-                queryBuilder.update("updated_date", new Date())
+                queryBuilder.update("updated_date", new Date().toISOString())
                 if (data.status) {
                     queryBuilder.update("status", data.status)
                 }

--- a/packages/admin-api/src/services/claims.service.ts
+++ b/packages/admin-api/src/services/claims.service.ts
@@ -71,7 +71,7 @@ export const updateClaim = async (id: string, username: string, data: any, trx?:
             .where("id", id)
             .modify((queryBuilder: any) => {
                 queryBuilder.update("updated_by", username)
-                queryBuilder.update("updated_date", new Date())
+                queryBuilder.update("updated_date", new Date().toISOString())
                 if (data.status) {
                     queryBuilder.update("status", data.status)
                 }

--- a/packages/admin-client/src/Applications/ApplicationList.tsx
+++ b/packages/admin-client/src/Applications/ApplicationList.tsx
@@ -67,7 +67,9 @@ export const ApplicationList = (props: any) => {
                                 sortByOrder="DESC"
                                 render={
                                     (record: any) =>
-                                        record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp
+                                        record.form_submitted_date
+                                            ? new Date(record.form_submitted_date).toLocaleDateString()
+                                            : "-" // remove timestamp
                                 }
                             />
                             <TextField label="Form Type" source="form_type" emptyText="-" />

--- a/packages/admin-client/src/Applications/ApplicationList.tsx
+++ b/packages/admin-client/src/Applications/ApplicationList.tsx
@@ -65,11 +65,10 @@ export const ApplicationList = (props: any) => {
                                 label="Submitted Date"
                                 sortBy="form_submitted_date,updated_date,created_date"
                                 sortByOrder="DESC"
-                                render={
-                                    (record: any) =>
-                                        record.form_submitted_date
-                                            ? new Date(record.form_submitted_date).toLocaleDateString()
-                                            : "-" // remove timestamp
+                                render={(record: any) =>
+                                    record.form_submitted_date
+                                        ? new Date(record.form_submitted_date).toLocaleDateString()
+                                        : "-"
                                 }
                             />
                             <TextField label="Form Type" source="form_type" emptyText="-" />

--- a/packages/admin-client/src/Claims/ClaimList.tsx
+++ b/packages/admin-client/src/Claims/ClaimList.tsx
@@ -73,7 +73,9 @@ export const ClaimList = (props: any) => {
                                 sortByOrder="DESC"
                                 render={
                                     (record: any) =>
-                                        record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp
+                                        record.form_submitted_date
+                                            ? new Date(record.form_submitted_date).toLocaleDateString()
+                                            : "-" // remove timestamp
                                 }
                             />
                             <TextField

--- a/packages/admin-client/src/Claims/ClaimList.tsx
+++ b/packages/admin-client/src/Claims/ClaimList.tsx
@@ -71,11 +71,10 @@ export const ClaimList = (props: any) => {
                                 label="Submitted Date"
                                 sortBy="form_submitted_date,updated_date,created_date"
                                 sortByOrder="DESC"
-                                render={
-                                    (record: any) =>
-                                        record.form_submitted_date
-                                            ? new Date(record.form_submitted_date).toLocaleDateString()
-                                            : "-" // remove timestamp
+                                render={(record: any) =>
+                                    record.form_submitted_date
+                                        ? new Date(record.form_submitted_date).toLocaleDateString()
+                                        : "-"
                                 }
                             />
                             <TextField

--- a/packages/employer-api/src/config/CREATE_SCRIPTS.sql
+++ b/packages/employer-api/src/config/CREATE_SCRIPTS.sql
@@ -10,11 +10,11 @@ CREATE TABLE IF NOT EXISTS public.applications
     num_positions integer,
     form_confirmation_id character varying(255) COLLATE pg_catalog."default",
     form_submission_id character varying(255) COLLATE pg_catalog."default",
-    form_submitted_date date,
+    form_submitted_date timestamptz,
     created_by character varying(255) COLLATE pg_catalog."default",
-    created_date date,
+    created_date timestamptz,
     updated_by character varying(255) COLLATE pg_catalog."default",
-    updated_date date,
+    updated_date timestamptz,
     stale boolean,
     CONSTRAINT applications_pkey PRIMARY KEY (id)
 )
@@ -36,14 +36,14 @@ CREATE TABLE IF NOT EXISTS public.claims
     associated_application_id character varying(10) COLLATE pg_catalog."default",
     form_confirmation_id character varying(255) COLLATE pg_catalog."default",
     form_submission_id character varying(255) COLLATE pg_catalog."default",
-    form_submitted_date date,
+    form_submitted_date timestamptz,
     service_provider_form_submission_id character varying(255) COLLATE pg_catalog."default",
     service_provider_form_internal_id character varying(255) COLLATE pg_catalog."default",
     calculator_approved boolean DEFAULT false,
     created_by character varying(255) COLLATE pg_catalog."default",
-    created_date date,
+    created_date timestamptz,
     updated_by character varying(255) COLLATE pg_catalog."default",
-    updated_date date,
+    updated_date timestamptz,
     stale boolean,
     CONSTRAINT claims_pkey PRIMARY KEY (id)
 )
@@ -73,9 +73,9 @@ CREATE TABLE IF NOT EXISTS public.employers
     workplace_province character varying(255) COLLATE pg_catalog."default",
     workplace_postal_code character varying(255) COLLATE pg_catalog."default",
     created_by character varying(255) COLLATE pg_catalog."default",
-    created_date date,
+    created_date timestamptz,
     updated_by character varying(255) COLLATE pg_catalog."default",
-    updated_date date,
+    updated_date timestamptz,
     CONSTRAINT employers_pkey PRIMARY KEY (id)
 )
 

--- a/packages/employer-api/src/services/application.service.ts
+++ b/packages/employer-api/src/services/application.service.ts
@@ -79,7 +79,7 @@ export const insertApplication = async (
         id,
         form_type: formType,
         form_submission_id: submissionID,
-        created_date: new Date(),
+        created_date: new Date().toISOString(),
         created_by: userGuid,
         status: "Draft",
         catchmentno: 5 // Temporary, for testing: set arbitrary catchment.
@@ -122,7 +122,7 @@ export const updateApplication = async (id: number, status: string | null, body:
                     : null,
                 status,
                 updated_by: "system",
-                updated_date: new Date(),
+                updated_date: new Date().toISOString(),
                 organization: body.submission.data.operatingName,
                 stale: false
             })

--- a/packages/employer-api/src/services/claim.service.ts
+++ b/packages/employer-api/src/services/claim.service.ts
@@ -71,7 +71,7 @@ export const insertClaim = async (
             form_submission_id: submissionID,
             position_title: application[0].position_title,
             associated_application_id: applicationID,
-            created_date: new Date(),
+            created_date: new Date().toISOString(),
             created_by: userGuid,
             status: "Draft",
             catchmentno: application[0].catchmentno,
@@ -111,7 +111,7 @@ export const updateClaim = async (id: number, status: string | null, body: any, 
                 employee_last_name: body.submission?.data?.container?.employeeLastName,
                 status,
                 updated_by: "system",
-                updated_date: new Date(),
+                updated_date: new Date().toISOString(),
                 stale: false
             })
     }
@@ -165,7 +165,7 @@ export const addServiceProviderClaim = async (
                     service_provider_form_submission_id: serviceProviderSubmissionID,
                     service_provider_form_internal_id: serviceProviderInternalID,
                     updated_by: submissionResponse.submission.updatedBy ?? submissionResponse.submission.createdBy,
-                    updated_date: new Date()
+                    updated_date: new Date().toISOString()
                 })
         } catch (e: any) {
             console.log(e.message)
@@ -200,7 +200,7 @@ export const updateServiceProviderClaim = async (submissionResponse: any) => {
                     status: "Completed",
                     calculator_approved: true,
                     updated_by: submissionResponse.submission.updatedBy ?? submissionResponse.submission.createdBy,
-                    updated_date: new Date()
+                    updated_date: new Date().toISOString()
                 })
         } catch (e: any) {
             console.log(e.message)

--- a/packages/employer-api/src/services/employer.service.ts
+++ b/packages/employer-api/src/services/employer.service.ts
@@ -23,7 +23,7 @@ export const insertEmployer = async (data: any) => {
     const employerData: any = {}
     employerData.id = data.id
     employerData.created_by = data.id
-    employerData.created_date = new Date()
+    employerData.created_date = new Date().toISOString()
     employerData.contact_name = data.contact_name
     employerData.contact_email = data.contact_email
     if (data.bceid_business_guid) {
@@ -53,7 +53,7 @@ export const updateEmployer = async (userGuid: string, data: any) => {
             .where("id", userGuid)
             .modify((queryBuilder: any) => {
                 queryBuilder.update("updated_by", userGuid)
-                queryBuilder.update("updated_date", new Date())
+                queryBuilder.update("updated_date", new Date().toISOString())
                 if (data?.bceid_business_guid || data.bceid_business_guid === null) {
                     queryBuilder.update("bceid_business_guid", data.bceid_business_guid)
                 }

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -127,12 +127,11 @@ export const ApplicationList = (props: any) => {
                                             label="Submitted Date"
                                             sortBy="form_submitted_date,updated_date,created_date"
                                             sortByOrder="DESC"
-                                            render={
-                                                (record: any) =>
-                                                    record.form_submitted_date
-                                                        ? record.form_submitted_date.split("T")[0]
-                                                        : "-" // remove timestamp
-                                            }
+                                            render={(record: any) => {
+                                                return record.form_submitted_date
+                                                    ? new Date(record.form_submitted_date).toLocaleDateString()
+                                                    : "-" // remove timestamp
+                                            }}
                                         />
                                         {allowSharing && <SharedWithField label="Shared With" openModal={openModal} />}
                                         <FunctionField

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -130,7 +130,7 @@ export const ApplicationList = (props: any) => {
                                             render={(record: any) => {
                                                 return record.form_submitted_date
                                                     ? new Date(record.form_submitted_date).toLocaleDateString()
-                                                    : "-" // remove timestamp
+                                                    : "-"
                                             }}
                                         />
                                         {allowSharing && <SharedWithField label="Shared With" openModal={openModal} />}

--- a/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
@@ -90,7 +90,9 @@ export const ClaimCreateSelectApplication = (props: any) => {
                             sortByOrder="DESC"
                             render={
                                 (record: any) =>
-                                    record.form_submitted_date ? record.form_submitted_date.split("T")[0] : "-" // remove timestamp
+                                    record.form_submitted_date
+                                        ? new Date(record.form_submitted_date).toLocaleDateString()
+                                        : "-" // remove timestamp
                             }
                         />
                         <FunctionField

--- a/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
@@ -88,11 +88,10 @@ export const ClaimCreateSelectApplication = (props: any) => {
                             label="Submitted Date"
                             sortBy="form_submitted_date,updated_date,created_date"
                             sortByOrder="DESC"
-                            render={
-                                (record: any) =>
-                                    record.form_submitted_date
-                                        ? new Date(record.form_submitted_date).toLocaleDateString()
-                                        : "-" // remove timestamp
+                            render={(record: any) =>
+                                record.form_submitted_date
+                                    ? new Date(record.form_submitted_date).toLocaleDateString()
+                                    : "-"
                             }
                         />
                         <FunctionField

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -133,7 +133,7 @@ export const ClaimList = (props: any) => {
                                             render={
                                                 (record: any) =>
                                                     record.form_submitted_date
-                                                        ? record.form_submitted_date.split("T")[0]
+                                                        ? new Date(record.form_submitted_date).toLocaleDateString()
                                                         : "-" // remove timestamp
                                             }
                                         />

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -130,11 +130,10 @@ export const ClaimList = (props: any) => {
                                             label="Submitted Date"
                                             sortBy="form_submitted_date,updated_date,created_date"
                                             sortByOrder="DESC"
-                                            render={
-                                                (record: any) =>
-                                                    record.form_submitted_date
-                                                        ? new Date(record.form_submitted_date).toLocaleDateString()
-                                                        : "-" // remove timestamp
+                                            render={(record: any) =>
+                                                record.form_submitted_date
+                                                    ? new Date(record.form_submitted_date).toLocaleDateString()
+                                                    : "-"
                                             }
                                         />
                                         <TextField


### PR DESCRIPTION
- [x] Use postgres timestamptz data type for all datetime columns in DB.
- [x] Whenever we create timestamps, use UTC timezone and ISO format to align with CHEFS and with BC Gov API development guidelines.
- [x] In client, convert UTC timestamps to local time before rendering.