### PR TITLE
TECH-588: fix bug where All filter breaks after changing perPage

### DIFF
--- a/packages/admin-client/src/Applications/ApplicationList.tsx
+++ b/packages/admin-client/src/Applications/ApplicationList.tsx
@@ -44,7 +44,7 @@ export const ApplicationList = (props: any) => {
                         {...props}
                         actions={<ListActions />}
                         filter={{ ...statusFilter, catchmentno: cc.catchment.id }}
-                        filterDefaultValues={{ ...statusFilter, catchmentno: cc.catchment.id }}
+                        filterDefaultValues={{ ...applicationStatusFilters["All"], catchmentno: cc.catchment.id }}
                         aside={
                             <ListAside
                                 statusFilters={applicationStatusFilters}

--- a/packages/admin-client/src/Claims/ClaimList.tsx
+++ b/packages/admin-client/src/Claims/ClaimList.tsx
@@ -43,7 +43,7 @@ export const ClaimList = (props: any) => {
                         {...props}
                         actions={<ListActions />}
                         filter={{ ...statusFilter, catchmentno: cc.catchment.id }}
-                        filterDefaultValues={{ ...statusFilter, catchmentno: cc.catchment.id }}
+                        filterDefaultValues={{ ...claimStatusFilters["All"], catchmentno: cc.catchment.id }}
                         aside={
                             <ListAside
                                 statusFilters={claimStatusFilters}

--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -97,7 +97,7 @@ export const ApplicationList = (props: any) => {
                                     {...props}
                                     actions={<ListActions createButtonLabel="New Application" />}
                                     filter={statusFilter}
-                                    filterDefaultValues={statusFilter}
+                                    filterDefaultValues={applicationStatusFilters["All"]}
                                     aside={
                                         <ListAside
                                             statusFilters={applicationStatusFilters}

--- a/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
+++ b/packages/employer-client/src/Claims/ClaimCreateSelectApplication.tsx
@@ -49,7 +49,7 @@ export const ClaimCreateSelectApplication = (props: any) => {
                     resource="applications"
                     filter={applicationStatusFilters["Completed"]}
                     filters={applicationFilters}
-                    filterDefaultValues={{ dummyUserFilter: -1 }} // TODO: filter by current user.
+                    filterDefaultValues={{ dummyFilter: -1 }} // Having at least 1 filter prevents redirection to default empty screen when empty.
                     actions={false} // Disable default list actions.
                     sx={{
                         "& .RaList-content": {

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -95,7 +95,7 @@ export const ClaimList = (props: any) => {
                                     {...props}
                                     actions={<ListActions createButtonLabel="New Claim Form" />}
                                     filter={statusFilter}
-                                    filterDefaultValues={statusFilter}
+                                    filterDefaultValues={claimStatusFilters["All"]}
                                     aside={
                                         <ListAside
                                             statusFilters={claimStatusFilters}


### PR DESCRIPTION
This PR attempts to fix a bug where if the user changes the rows per page while the status filter is set to any value other than 'All', then returning to the 'All' filter has no effect, ie the 'All' filter permanently breaks.

After changing rows per page and returning to the 'All' filter, the filter values being passed into the List were correct, but the filter values in the resulting request to the API were wrong and still included the previous status filter. ie if the previous filter was 'Draft', then after returning to 'All' the filters sent in the request were:

label: All
status: Draft

It's unclear how the filters in the request were being set this way, it may be some internal functionality of React Admin.

The issue appears to resolve after setting the list filter default values to the 'All' filter, rather than the state variable statusFilter.

Changes are as follows:

- [x] Do not use state variable statusFilter for filterDefaultValues; instead use the All filter.
- [x] In ClaimCreateSelectApplication, add comment explaining use of dummy filter.