### PR TITLE
TECH-630: fix bug where workplace province unassignable after prefill

### DIFF
--- a/packages/employer-api/src/controllers/application.controller.ts
+++ b/packages/employer-api/src/controllers/application.controller.ts
@@ -275,7 +275,7 @@ const computeApplicationPrefillFields = (employer: any) => ({
     container: {
         ...(employer?.workplace_street_address && { addressAlt: employer.workplace_street_address }),
         ...(employer?.workplace_city && { cityAlt: employer.workplace_city }),
-        ...(employer?.workplace_province && { provinceAlt: employer.workplace_province }),
+        provinceAlt: "BC",
         ...(employer?.workplace_postal_code && { postalAlt: employer.workplace_postal_code })
     },
     ...(employer?.contact_name && { signatory1: employer.contact_name })


### PR DESCRIPTION
This PR fixes a bug where a null value could be passed from the employer profile into the workplace province in the form. Since the workplace province isn't editable in the form then the workplace address could not be validated. Changes:

- [x] Always pass value BC into workplace address so it is never null in the form.