### PR TITLE
TECH-621: permit backfill even if application notification fails

### DIFF
--- a/packages/admin-api/src/controllers/application.controller.ts
+++ b/packages/admin-api/src/controllers/application.controller.ts
@@ -2,13 +2,13 @@
 /* eslint-disable import/prefer-default-export */
 import * as express from "express"
 
-import { getCatchments } from "../lib/catchment"
-import * as applicationService from "../services/application.service"
-import * as formService from "../services/form.service"
-import { generatePdf } from "../services/cdogs.service"
-import { updateApplicationWithSideEffects } from "../lib/transactions"
-import { formatDateMmmDDYYYY } from "../utils/string-functions"
 import WorkBcCentres from "../data/workbc-centres"
+import { getCatchments } from "../lib/catchment"
+import { updateApplicationWithSideEffects } from "../lib/transactions"
+import * as applicationService from "../services/application.service"
+import { generatePdf } from "../services/cdogs.service"
+import * as formService from "../services/form.service"
+import { formatCurrency, formatDateMmmDDYYYY } from "../utils/string-functions"
 
 const workBcCentreCodes = Object.keys(WorkBcCentres)
 
@@ -229,7 +229,7 @@ export const generatePDF = async (req: any, res: express.Response) => {
             numberOfPositions0: submission.data?.numberOfPositions0,
             startDate0: formatDateMmmDDYYYY(submission.data?.startDate0),
             hours0: submission.data?.hours0,
-            wage0: submission.data?.wage0,
+            wage0: formatCurrency(submission.data?.wage0),
             duties0: submission.data?.duties0,
             skills0: submission.data?.skills0,
             workExperience0: submission.data?.workExperience0,
@@ -242,7 +242,7 @@ export const generatePDF = async (req: any, res: express.Response) => {
             numberOfPositions1: submission.data.position2?.numberOfPositions1,
             startDate1: formatDateMmmDDYYYY(submission.data.position2?.startDate1),
             hours1: submission.data.position2?.hours1,
-            wage1: submission.data.position2?.wage1,
+            wage1: formatCurrency(submission.data.position2?.wage1),
             duties1: submission.data.position2?.duties1,
             skills1: submission.data.position2?.skills1,
             workExperience1: submission.data.position2?.workExperience1,

--- a/packages/employer-api/src/controllers/event.controller.ts
+++ b/packages/employer-api/src/controllers/event.controller.ts
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
 /* eslint-disable import/prefer-default-export */
 import * as express from "express"
-import * as formService from "../services/form.service"
 import * as applicationService from "../services/application.service"
 import * as claimService from "../services/claim.service"
-import * as emailController from "./email.controller"
 import * as employerService from "../services/employer.service"
+import * as formService from "../services/form.service"
+import * as emailController from "./email.controller"
 
 export const submission = async (req: express.Request, res: express.Response) => {
     try {
@@ -139,7 +139,6 @@ export const submission = async (req: express.Request, res: express.Response) =>
                         submissionResponse.submission,
                         false
                     )
-                    await emailController.sendEmail(submissionResponse.submission.submission)
                     // If first application submitted, backfill employer profile from form data.
                     const firstApplicationSubmitted = await applicationService.oneApplicationSubmitted(
                         application.created_by
@@ -154,6 +153,7 @@ export const submission = async (req: express.Request, res: express.Response) =>
                             submissionResponse.submission.submission.data
                         )
                     }
+                    await emailController.sendEmail(submissionResponse.submission.submission)
                 } else if (submissionResponse.submission.draft === true) {
                     console.log("updating saved application for id ", application.id)
                     updateResult = await applicationService.updateApplication(

--- a/workbc-wage-subsidy.code-workspace
+++ b/workbc-wage-subsidy.code-workspace
@@ -19,8 +19,8 @@
             "editor.tabSize": 4
         },
         "editor.codeActionsOnSave": {
-            "source.fixAll": true,
-            "source.organizeImports": true
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
         },
         "editor.formatOnSave": true,
         "editor.rulers": [150],

--- a/workbc-wage-subsidy.code-workspace
+++ b/workbc-wage-subsidy.code-workspace
@@ -1,34 +1,34 @@
 {
-  "extensions": {
-    "recommendations": [
-      "christian-kohler.path-intellisense",
-      "dbaeumer.vscode-eslint",
-      "esbenp.prettier-vscode",
-      "orta.vscode-jest",
-      "vscode-icons-team.vscode-icons"
-    ]
-  },
-  "folders": [
-    {
-      "path": "."
+    "extensions": {
+        "recommendations": [
+            "christian-kohler.path-intellisense",
+            "dbaeumer.vscode-eslint",
+            "esbenp.prettier-vscode",
+            "orta.vscode-jest",
+            "vscode-icons-team.vscode-icons"
+        ]
+    },
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        "[javascript][javascriptreact][json][jsonc][typescript][typescriptreact]": {
+            "editor.defaultFormatter": "esbenp.prettier-vscode",
+            "editor.tabSize": 4
+        },
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        },
+        "editor.formatOnSave": true,
+        "editor.rulers": [150],
+        "javascript.format.semicolons": "remove",
+        "javascript.preferences.quoteStyle": "double",
+        "typescript.format.semicolons": "remove",
+        "typescript.preferences.importModuleSpecifier": "project-relative",
+        "typescript.preferences.quoteStyle": "double",
+        "typescript.tsdk": "node_modules/typescript/lib"
     }
-  ],
-  "settings": {
-    "[javascript][javascriptreact][json][jsonc][typescript][typescriptreact]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode",
-      "editor.tabSize": 4
-    },
-    "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": true
-    },
-    "editor.formatOnSave": true,
-    "editor.rulers": [150],
-    "javascript.format.semicolons": "remove",
-    "javascript.preferences.quoteStyle": "double",
-    "typescript.format.semicolons": "remove",
-    "typescript.preferences.importModuleSpecifier": "project-relative",
-    "typescript.preferences.quoteStyle": "double",
-    "typescript.tsdk": "node_modules/typescript/lib"
-  }
 }

--- a/workbc-wage-subsidy.code-workspace
+++ b/workbc-wage-subsidy.code-workspace
@@ -19,8 +19,8 @@
             "editor.tabSize": 4
         },
         "editor.codeActionsOnSave": {
-            "source.fixAll": "explicit",
-            "source.organizeImports": "explicit"
+            "source.fixAll": true,
+            "source.organizeImports": true
         },
         "editor.formatOnSave": true,
         "editor.rulers": [150],


### PR DESCRIPTION
This PR fixes a bug where backfill would not occur if the application submission notification failed.

- [x] Perform backfill before sending notification so backfill operation is not contingent on notification success.

This PR also adds the correct currency formatting for the hourly wage in application PDFs (TECH 640), and commits the new formatting changes to the code-workspace file applied by VSCode 18.5.