### PR TITLE
TECH648: prevent duplicate service provider claim forms

### DIFF
--- a/packages/employer-api/src/controllers/application.controller.ts
+++ b/packages/employer-api/src/controllers/application.controller.ts
@@ -273,6 +273,9 @@ const computeApplicationPrefillFields = (employer: any) => ({
             otherWorkAddress: false
         }),
     container: {
+        ...((employer?.workplace_street_address || employer?.workplace_city || employer?.workplace_postal_code) && {
+            addressValidationAlt: "Validation required to continue."
+        }),
         ...(employer?.workplace_street_address && { addressAlt: employer.workplace_street_address }),
         ...(employer?.workplace_city && { cityAlt: employer.workplace_city }),
         provinceAlt: "BC",


### PR DESCRIPTION
This PR fixes an issue where duplicate service provider claim forms could be created. It also fixes a minor issue where the workplace address validation result was not set to the correct default value when the workplace address was prefilled. Changes are as follows:

- [x] In claim submission event handler only create sp claim form if one does not exist.
- [x] When workplace address is prefilled set workplace address validation result to correct default value.