### PR TITLE
Bug: Typos in Notification Email Template

### DIFF
--- a/packages/employer-api/src/templates/notification.template.ts
+++ b/packages/employer-api/src/templates/notification.template.ts
@@ -8,9 +8,9 @@ const applicationNotification = (catchmentNo: string, catchmentName: string, typ
         `A Wage Subsidy${type === "claim" ? " Claim" : ""} Application has been submitted`,
         [
             ` Hello `,
-            ` You are receiving this email because you enabled notifications on Wage Subsidy${
-                type === "claim" ? " Claim" : ""
-            } Applications for Catchment ${catchmentNo} - ${catchmentName}.`
+            ` You are receiving this email because you enabled notifications on Wage Subsidy ${
+                type === "claim" ? "Claim Forms" : "Applications"
+            } for Catchment ${catchmentNo} - ${catchmentName}.`
         ],
         [
             `Please log into the <a href="${

--- a/packages/employer-api/src/templates/notification.template.ts
+++ b/packages/employer-api/src/templates/notification.template.ts
@@ -5,7 +5,7 @@ const applicationNotification = (catchmentNo: string, catchmentName: string, typ
     const claimsUrl = `${process.env.WAGE_SUB_URL}/#/claims`
     const applicationsUrl = `${process.env.WAGE_SUB_URL}/#/applications`
     const email = generateHTMLEmail(
-        `A Wage Subsidy${type === "claim" ? " Claim" : ""} Application has been submitted`,
+        `A Wage Subsidy ${type === "claim" ? "Claim Form" : "Application"} has been submitted`,
         [
             ` Hello `,
             ` You are receiving this email because you enabled notifications on Wage Subsidy ${


### PR DESCRIPTION
Description of changes:
- Updated email body in template to say "Wage Subsidy Claim Forms" for Claims and "Wage Subsidy Applications" for Applications.
- Updated email title in template to say "Wage Subsidy Claim Form" for Claim and "Wage Subsidy Application" for Application.