### PR TITLE
Tech 584 keyboard hover indicator sizing

### DIFF
--- a/packages/admin-client/src/common/components/CustomDatagridRow/CustomDatagridRow.tsx
+++ b/packages/admin-client/src/common/components/CustomDatagridRow/CustomDatagridRow.tsx
@@ -154,7 +154,7 @@ const DatagridRow: FC<any> = React.forwardRef((props, ref) => {
                                 checked={selectable && selected}
                                 onClick={handleToggleSelection}
                                 disabled={!selectable}
-                                sx={{ alignItems: "start", padding: "6px 9px" }}
+                                sx={{ alignItems: "start", padding: "0.4em 0.6em" }}
                             />
                         )}
                         <Box width="100%" justifyContent="center" alignSelf="center">

--- a/packages/admin-client/src/common/components/CustomDatagridRow/CustomDatagridRow.tsx
+++ b/packages/admin-client/src/common/components/CustomDatagridRow/CustomDatagridRow.tsx
@@ -128,12 +128,16 @@ const DatagridRow: FC<any> = React.forwardRef((props, ref) => {
             >
                 {/* First column: row button, checkbox, PDF button, and optional calculator button */}
                 <TableCell padding="none">
-                    <Box display="flex" padding="0em 0em 0em 0.53em" minHeight="2.6em">
+                    <Box display="flex" padding="0em 0em 0em 0.53em" height="100%">
                         <Button
                             sx={{
+                                display: "flex",
+                                flexGrow: "1",
                                 position: "absolute",
-                                width: "99%",
-                                height: "3em",
+                                left: 0,
+                                width: "100%",
+                                height: "100%",
+                                alignItems: "stretch",
                                 backgroundColor: "transparent",
                                 "&:hover": {
                                     backgroundColor: "transparent"
@@ -150,6 +154,7 @@ const DatagridRow: FC<any> = React.forwardRef((props, ref) => {
                                 checked={selectable && selected}
                                 onClick={handleToggleSelection}
                                 disabled={!selectable}
+                                sx={{ alignItems: "start", padding: "6px 9px" }}
                             />
                         )}
                         <Box width="100%" justifyContent="center" alignSelf="center">

--- a/packages/admin-client/src/common/components/PdfButtonField/PdfButtonField.tsx
+++ b/packages/admin-client/src/common/components/PdfButtonField/PdfButtonField.tsx
@@ -38,7 +38,7 @@ const PdfButtonField: React.FC = () => {
                     getPdf(formType)
                 }
             }}
-            sx={{ minWidth: "3em" }}
+            sx={{ minWidth: "3em", padding: "0.6em" }}
             aria-label="Generate PDF"
         >
             <FontAwesomeIcon icon={faFilePdf} size="xl" style={{ color: COLOURS.LIGHTBLUE_TEXT }} />

--- a/packages/admin-client/src/common/styles/DatagridStyles.tsx
+++ b/packages/admin-client/src/common/styles/DatagridStyles.tsx
@@ -18,5 +18,8 @@ export const DatagridStyles = {
     "& .RaDatagrid-headerCell": {
         fontWeight: "bold",
         textAlign: "left"
+    },
+    "& .MuiTableRow-root": {
+        position: "relative"
     }
 }

--- a/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagridRow.tsx
+++ b/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagridRow.tsx
@@ -131,12 +131,16 @@ const DatagridRow: FC<CustomDatagridRowProps> = React.forwardRef((props, ref) =>
             >
                 {/* First column: row button, checkbox */}
                 <TableCell padding="none">
-                    <Box display="flex" padding="0em 0em 0em 0.53em" minHeight="2.6em">
+                    <Box display="flex" padding="0em 0em 0em 0.53em" height="100%">
                         <Button
                             sx={{
+                                display: "flex",
+                                flexGrow: "1",
                                 position: "absolute",
-                                width: "99%",
-                                height: "3em",
+                                left: 0,
+                                width: "100%",
+                                height: "100%",
+                                alignItems: "stretch",
                                 backgroundColor: "transparent",
                                 "&:hover": {
                                     backgroundColor: "transparent"
@@ -159,6 +163,7 @@ const DatagridRow: FC<CustomDatagridRowProps> = React.forwardRef((props, ref) =>
                                 checked={selectable && selected}
                                 onClick={handleToggleSelection}
                                 disabled={!selectable}
+                                sx={{ alignItems: "start", padding: "6px 9px" }}
                             />
                         )}
                     </Box>

--- a/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagridRow.tsx
+++ b/packages/employer-client/src/common/components/CustomDatagrid/CustomDatagridRow.tsx
@@ -163,7 +163,7 @@ const DatagridRow: FC<CustomDatagridRowProps> = React.forwardRef((props, ref) =>
                                 checked={selectable && selected}
                                 onClick={handleToggleSelection}
                                 disabled={!selectable}
-                                sx={{ alignItems: "start", padding: "6px 9px" }}
+                                sx={{ alignItems: "start", padding: "0.4em 0.6em" }}
                             />
                         )}
                     </Box>

--- a/packages/employer-client/src/common/styles/DatagridStyles.tsx
+++ b/packages/employer-client/src/common/styles/DatagridStyles.tsx
@@ -21,5 +21,8 @@ export const DatagridStyles = {
     "& .RaDatagrid-headerCell": {
         fontWeight: "bold",
         textAlign: "left"
+    },
+    "& .MuiTableRow-root": {
+        position: "relative"
     }
 }


### PR DESCRIPTION
Highlighting the row via tab (keyboard hover indicator) now is expanded for the whole row's height, as requested in the ticket. 
In terms of width it doesn't seem possible to highlight the entire row.

![image](https://github.com/bcgov/workbc-wage-subsidy/assets/22423987/17e3a04a-3c71-4828-9a63-b16e58b99a8b)

Ticket: https://elmsdjira.ca/browse/TECH-584