### PR TITLE
Fix logout page path

### DIFF
--- a/packages/admin-client/src/Auth/LoginPage.tsx
+++ b/packages/admin-client/src/Auth/LoginPage.tsx
@@ -8,7 +8,7 @@ const LoginPage = () => {
     return (
         <Button
             onClick={() => {
-                keycloak.logout({ redirectUri: `${absolutePath}/logout-success` })
+                keycloak.logout({ redirectUri: `${absolutePath}logout-success` })
                 localStorage.removeItem("token")
                 localStorage.removeItem("refresh_token")
                 localStorage.removeItem("permissions")

--- a/packages/admin-client/src/Auth/authProvider.tsx
+++ b/packages/admin-client/src/Auth/authProvider.tsx
@@ -20,7 +20,7 @@ const useAuthProvider = () => {
             localStorage.removeItem("permissions")
             localStorage.removeItem("access")
             localStorage.clear()
-            return keycloak.logout({ redirectUri: `${absolutePath}/logout-success` })
+            return keycloak.logout({ redirectUri: `${absolutePath}logout-success` })
         },
         getIdentity: () => {
             if (keycloak.token) {

--- a/packages/admin-client/src/utils/index.ts
+++ b/packages/admin-client/src/utils/index.ts
@@ -4,15 +4,15 @@ const APP_ENV = process.env.REACT_APP_ENVIRONMENT || "Local Dev"
 export const setAbsoluteWageSubUrl = (): string => {
     switch (APP_ENV) {
         case "Local Dev":
-            return "http://localhost:3000"
+            return "http://localhost:3000/"
         case "TEST":
             return "https://wage-sub-test.es.workbc.ca/"
         case "DEV":
-            return "https://wage-sub-dev.es.workbc.ca"
+            return "https://wage-sub-dev.es.workbc.ca/"
         case "PRODUCTION":
             return "https://wage-subsidy.es.workbc.ca/"
         default:
-            return "http://localhost:3000"
+            return "http://localhost:3000/"
     }
 }
 

--- a/packages/employer-client/src/Auth/authProvider.tsx
+++ b/packages/employer-client/src/Auth/authProvider.tsx
@@ -15,7 +15,7 @@ const useAuthProvider = (clientID: string) => {
             localStorage.removeItem("token")
             localStorage.removeItem("refresh_token")
             localStorage.removeItem("permissions")
-            return keycloak.logout({ redirectUri: `${absolutePath}/logout-success` })
+            return keycloak.logout({ redirectUri: `${absolutePath}logout-success` })
         },
         getIdentity: () => {
             if (keycloak.token) {

--- a/packages/employer-client/src/utils/index.ts
+++ b/packages/employer-client/src/utils/index.ts
@@ -4,15 +4,15 @@ const APP_ENV = process.env.REACT_APP_ENVIRONMENT || "Local Dev"
 export const setAbsoluteWageSubUrl = (): string => {
     switch (APP_ENV) {
         case "Local Dev":
-            return "http://localhost:3000"
+            return "http://localhost:3000/"
         case "TEST":
             return "https://wage-sub-test.es.workbc.ca/"
         case "DEV":
-            return "https://wage-sub-dev.es.workbc.ca"
+            return "https://wage-sub-dev.es.workbc.ca/"
         case "PRODUCTION":
             return "https://wage-subsidy.es.workbc.ca/"
         default:
-            return "http://localhost:3000"
+            return "http://localhost:3000/"
     }
 }
 


### PR DESCRIPTION
The issue was in prod we had `//logout-success` which leaded to 404 page

The dev env testing passed because it had different base url compared to prod. 
The update included to bring base url to standard across all environments 