### PR TITLE
add accessibility modal to admin/employer

### DIFF
--- a/packages/admin-client/src/CustomHeader.tsx
+++ b/packages/admin-client/src/CustomHeader.tsx
@@ -1,14 +1,18 @@
-import { AppBar, AppBarProps, Box, Link, Toolbar } from "@mui/material"
+import { AppBar, AppBarProps, Box, Link, Toolbar, Button } from "@mui/material"
 import { styled } from "@mui/material/styles"
 import { HorizontalMenu, useContainerLayout } from "@react-admin/ra-navigation"
-import React from "react"
+import React, { useState } from "react"
 import { LoadingIndicator, LocalesMenuButton, TitleComponent, UserMenu, useLocales } from "react-admin"
 import { Link as RouterLink } from "react-router-dom"
 import Logo from "./Logo"
 import Tag from "./Tag"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faEyeLowVision } from "@fortawesome/pro-solid-svg-icons"
+import BCGovModal from "./common/components/BCGovModal/BCGovModal"
 
 export const Header = (props: HeaderProps) => {
     const { menu = defaultMenu, toolbar = defaultToolbar, userMenu = defaultUserMenu } = useContainerLayout(props)
+    const [accessibilityFeaturesModalIsOpen, setAccessibilityFeaturesModalIsOpen] = useState(false)
 
     return (
         <>
@@ -57,8 +61,81 @@ export const Header = (props: HeaderProps) => {
                     }}
                 >
                     <Box>{menu}</Box>
+                    <Button
+                        sx={{
+                            display: "flex",
+                            flexDirection: "row",
+                            alignItems: "center",
+                            cursor: "pointer",
+                            fontSize: "14px",
+                            color: "rgb(255, 255, 255)",
+                            textTransform: "none",
+                            ":hover": {
+                                textDecoration: "underline"
+                            }
+                        }}
+                        onClick={() => setAccessibilityFeaturesModalIsOpen(true)}
+                    >
+                        <FontAwesomeIcon icon={faEyeLowVision} size="2x" style={{ marginRight: 15 }} />
+                        Accessibility Features
+                    </Button>
                 </Toolbar>
             </Root2>
+            <BCGovModal
+                isOpen={accessibilityFeaturesModalIsOpen}
+                onRequestClose={() => setAccessibilityFeaturesModalIsOpen(false)}
+                contentLabel="Accessibility Features"
+            >
+                <div className="accessibility-features-modal-container">
+                    <div className="accessibility-features-title">
+                        <h1>Accessibility Features</h1>
+                        <div>
+                            The Wage Subsidy application has been developed following the BC Government's{" "}
+                            <a
+                                href="https://www2.gov.bc.ca/gov/content/home/accessible-government/toolkit"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Accessibility and Inclusion Toolkit
+                            </a>
+                            , and specifically the{" "}
+                            <a href="https://www.w3.org/WAI/tips/developing/">W3 Developing for Web Accessibility</a>{" "}
+                            best practices.
+                        </div>
+                    </div>
+                    <div className="accessiblity-features-content">
+                        <h2>Form Completion</h2>
+                        <div>
+                            For applications and claim forms, we use embedded form functionality within the Wage Subsidy
+                            application. For screen readers, use the 'Open form in new tab' icon link to allow your
+                            screen reader to properly read out and allow you to work with form fields.
+                        </div>
+                        <h2>Labels and tool tips</h2>
+                        <div>
+                            Labels and tool tips have been added to provide additional explanation for areas, fields and
+                            actions within the application. Some of these labels may be hidden visually but will be read
+                            out with screen readers.
+                        </div>
+                        <h2>Navigation</h2>
+                        <div>
+                            Users can navigate between the list of applications or claim forms and the status filter
+                            sidebar (left-hand portion of the screen) using the left and right arrow keys.
+                        </div>
+                        <h2>Checkboxes</h2>
+                        <div>
+                            Selecting a given checkbox will enable additional actions to appear at the top of the list
+                            of applications or claim forms. <br />
+                            <br />
+                            For Employers, this action allows the user to <b>share</b> selected applications and claim
+                            forms with others within your Business BCeID organization. Note this function is not
+                            available for Basic BCeID users. <br />
+                            <br />
+                            For Ministry Staff, this action allows the user to <b>move</b> applications and claim forms
+                            from one catchment to another.
+                        </div>
+                    </div>
+                </div>
+            </BCGovModal>
         </>
     )
 }

--- a/packages/admin-client/src/common/components/BCGovModal/BCGovModal.tsx
+++ b/packages/admin-client/src/common/components/BCGovModal/BCGovModal.tsx
@@ -13,7 +13,8 @@ const modalStyles = {
         borderRadius: "6px",
         maxWidth: "47em",
         boxShadow: "0 0 30px 0 rgb(0 0 0 / 15%)",
-        maxHeight: "80%"
+        maxHeight: "80%",
+        fontFamily: "'BCSans', 'Noto Sans', Verdana, Arial, sans-serif"
     },
     overlay: {
         backgroundColor: "rgba(210, 210, 210, 0.58)",

--- a/packages/employer-client/src/CustomHeader.tsx
+++ b/packages/employer-client/src/CustomHeader.tsx
@@ -4,17 +4,19 @@ import { Toolbar, AppBar, AppBarProps, Box, Link, Button } from "@mui/material"
 import { styled } from "@mui/material/styles"
 import { UserMenu, LoadingIndicator, LocalesMenuButton, TitleComponent, useLocales } from "react-admin"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faBookOpenReader } from "@fortawesome/pro-solid-svg-icons"
+import { faBookOpenReader, faEyeLowVision } from "@fortawesome/pro-solid-svg-icons"
 import { useContainerLayout, HorizontalMenu } from "@react-admin/ra-navigation"
 import Logo from "./Logo"
 import Tag from "./Tag"
 import { CustomUserMenu } from "./CustomUserMenu"
 import UserProfileModal from "./UserProfileModal"
 import EmployerHandbook from "./assets/Wage-Subsidy-Handbook.pdf"
+import BCGovModal from "./common/components/BCGovModal/BCGovModal"
 
 export const Header = (props: HeaderProps) => {
     const { menu = defaultMenu, toolbar = defaultToolbar, userMenu = defaultUserMenu } = useContainerLayout(props)
     const [modalIsOpen, setModalIsOpen] = useState(false)
+    const [accessibilityFeaturesModalIsOpen, setAccessibilityFeaturesModalIsOpen] = useState(false)
 
     const openModal = useCallback(() => {
         setModalIsOpen(true)
@@ -77,29 +79,108 @@ export const Header = (props: HeaderProps) => {
                     }}
                 >
                     <Box>{menu}</Box>
-                    <Button
-                        sx={{
-                            display: "flex",
-                            flexDirection: "row",
-                            alignItems: "center",
-                            cursor: "pointer",
-                            fontSize: "14px",
-                            color: "rgb(255, 255, 255)",
-                            textTransform: "none",
-                            ":hover": {
-                                textDecoration: "underline"
-                            }
-                        }}
-                        onClick={() => window.open(EmployerHandbook)}
-                    >
-                        <FontAwesomeIcon icon={faBookOpenReader} size="2x" style={{ marginRight: 15 }} />
-                        Employer Handbook
-                    </Button>
+                    <div style={{ display: "flex", flexDirection: "row" }}>
+                        <Button
+                            sx={{
+                                display: "flex",
+                                flexDirection: "row",
+                                alignItems: "center",
+                                cursor: "pointer",
+                                fontSize: "14px",
+                                color: "rgb(255, 255, 255)",
+                                textTransform: "none",
+                                ":hover": {
+                                    textDecoration: "underline"
+                                }
+                            }}
+                            onClick={() => setAccessibilityFeaturesModalIsOpen(true)}
+                        >
+                            <FontAwesomeIcon icon={faEyeLowVision} size="2x" style={{ marginRight: 15 }} />
+                            Accessibility Features
+                        </Button>
+                        <Button
+                            sx={{
+                                display: "flex",
+                                flexDirection: "row",
+                                alignItems: "center",
+                                cursor: "pointer",
+                                fontSize: "14px",
+                                color: "rgb(255, 255, 255)",
+                                textTransform: "none",
+                                ":hover": {
+                                    textDecoration: "underline"
+                                }
+                            }}
+                            onClick={() => window.open(EmployerHandbook)}
+                        >
+                            <FontAwesomeIcon icon={faBookOpenReader} size="2x" style={{ marginRight: 15 }} />
+                            Employer Handbook
+                        </Button>
+                    </div>
                 </Toolbar>
             </Root2>
             {/* Mount modal outside of CustomUserMenu. */}
             {/* Then menu can close when modal opens, allowing modal to receive focus. */}
             <UserProfileModal isOpen={modalIsOpen} onRequestClose={closeModal} contentLabel="Update user profile" />
+            <BCGovModal
+                isOpen={accessibilityFeaturesModalIsOpen}
+                onRequestClose={() => setAccessibilityFeaturesModalIsOpen(false)}
+                contentLabel="Accessibility Features"
+            >
+                <div className="accessibility-features-modal-container">
+                    <div className="accessibility-features-title">
+                        <h1>Accessibility Features</h1>
+                        <div>
+                            The Wage Subsidy application has been developed following the BC Government's
+                            <a
+                                href="https://www2.gov.bc.ca/gov/content/home/accessible-government/toolkit"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {" "}
+                                Accessibility and Inclusion Toolkit
+                            </a>
+                            , and specifically the
+                            <a href="https://www.w3.org/WAI/tips/developing/">
+                                {" "}
+                                W3 Developing for Web Accessibility
+                            </a>{" "}
+                            best practices.
+                        </div>
+                    </div>
+                    <div className="accessiblity-features-content">
+                        <h2>Form Completion</h2>
+                        <div>
+                            For applications and claim forms, we use embedded form functionality within the Wage Subsidy
+                            application. For screen readers, use the 'Open form in new tab' icon link to allow your
+                            screen reader to properly read out and allow you to work with form fields.
+                        </div>
+                        <h2>Labels and tool tips</h2>
+                        <div>
+                            Labels and tool tips have been added to provide additional explanation for areas, fields and
+                            actions within the application. Some of these labels may be hidden visually but will be read
+                            out with screen readers.
+                        </div>
+                        <h2>Navigation</h2>
+                        <div>
+                            Users can navigate between the list of applications or claim forms and the status filter
+                            sidebar (left-hand portion of the screen) using the left and right arrow keys.
+                        </div>
+                        <h2>Checkboxes</h2>
+                        <div>
+                            Selecting a given checkbox will enable additional actions to appear at the top of the list
+                            of applications or claim forms. <br />
+                            <br />
+                            For Employers, this action allows the user to <b>share</b> selected applications and claim
+                            forms with others within your Business BCeID organization. Note this function is not
+                            available for Basic BCeID users. <br />
+                            <br />
+                            For Ministry Staff, this action allows the user to <b>move</b> applications and claim forms
+                            from one catchment to another.
+                        </div>
+                    </div>
+                </div>
+            </BCGovModal>
         </>
     )
 }

--- a/packages/employer-client/src/common/components/BCGovModal/BCGovModal.tsx
+++ b/packages/employer-client/src/common/components/BCGovModal/BCGovModal.tsx
@@ -13,7 +13,8 @@ const modalStyles = {
         borderRadius: "6px",
         maxWidth: "47em",
         boxShadow: "0 0 30px 0 rgb(0 0 0 / 15%)",
-        maxHeight: "80%"
+        maxHeight: "80%",
+        fontFamily: "'BCSans', 'Noto Sans', Verdana, Arial, sans-serif"
     },
     overlay: {
         backgroundColor: "rgba(210, 210, 210, 0.58)",


### PR DESCRIPTION
Ticket: https://sdpr-elmsd.atlassian.net/browse/WS-6

Added the accessibility features modal to both Admin and Employer client on the top right of the page.
Admin only has the accessibility features button, whereas Employer has both.

Admin:
![image](https://github.com/user-attachments/assets/08c8e57f-34c5-46c8-b800-f0c846a3f39e)

Employer: 
![image](https://github.com/user-attachments/assets/30e7a30c-bb62-481b-ad41-9f7290fe4006)
