### PR TITLE
fix misalignment of list in employer client

### DIFF
--- a/packages/employer-client/src/Applications/ApplicationList.tsx
+++ b/packages/employer-client/src/Applications/ApplicationList.tsx
@@ -87,7 +87,7 @@ export const ApplicationList = (props: any) => {
 
     return (
         <>
-            <Box id="main-content-custom" tabIndex={0} aria-label="main content">
+            <Box id="main-content-custom" tabIndex={0} aria-label="main content" mt={1}>
                 {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
                 {identity !== undefined && (
                     <>

--- a/packages/employer-client/src/Claims/ClaimList.tsx
+++ b/packages/employer-client/src/Claims/ClaimList.tsx
@@ -97,7 +97,7 @@ export const ClaimList = (props: any) => {
 
     return (
         <>
-            <Box id="main-content-custom" tabIndex={0} aria-label="main content">
+            <Box id="main-content-custom" tabIndex={0} aria-label="main content" mt={1}>
                 {!ready && <Loading sx={{ marginTop: 20 }}></Loading>}
                 {identity !== undefined && (
                     <>

--- a/packages/employer-client/src/common/components/ListActions/ListActions.tsx
+++ b/packages/employer-client/src/common/components/ListActions/ListActions.tsx
@@ -5,7 +5,7 @@ interface ListActionsProps {
 }
 
 export const ListActions: React.FC<ListActionsProps> = ({ createButtonLabel }) => (
-    <TopToolbar sx={{ paddingTop: "5vh" }}>
+    <TopToolbar>
         <div>
             <CreateButton label={createButtonLabel} />
         </div>

--- a/packages/employer-client/src/common/components/ListAside/ListAside.tsx
+++ b/packages/employer-client/src/common/components/ListAside/ListAside.tsx
@@ -79,7 +79,7 @@ export const ListAside: React.FC<ListAsideProps> = ({ statusFilters, statusFilte
     }, [])
 
     return (
-        <Box width={200} mr={1} mt={7} flexShrink={0} order={-1} style={{ transform: "translate(0em, -1.7em)" }}>
+        <Box width={200} mr={1} mt={1.5} flexShrink={0} order={-1}>
             <Box style={{ transform: "translate(0em, -0.5em)" }}>
                 <span
                     style={{


### PR DESCRIPTION
Ticket: https://sdpr-elmsd.atlassian.net/browse/WS-20

Aligned the list in the employer client so it matches the rest of the lists

Before:
![image](https://github.com/user-attachments/assets/69f5ce0f-427b-4044-991b-ea5934c01047)

After:
![image](https://github.com/user-attachments/assets/bff5f9ec-3ff7-41e9-b2da-2bbc8fec4a0d)
