### PR TITLE
change text, add click to open to new tab

### DIFF
--- a/packages/admin-client/src/CustomHeader.tsx
+++ b/packages/admin-client/src/CustomHeader.tsx
@@ -99,7 +99,9 @@ export const Header = (props: HeaderProps) => {
                                 Accessibility and Inclusion Toolkit
                             </a>
                             , and specifically the{" "}
-                            <a href="https://www.w3.org/WAI/tips/developing/">W3 Developing for Web Accessibility</a>{" "}
+                            <a href="https://www.w3.org/WAI/tips/developing/" target="_blank" rel="noreferrer">
+                                W3 Developing for Web Accessibility
+                            </a>{" "}
                             best practices.
                         </div>
                     </div>
@@ -110,7 +112,7 @@ export const Header = (props: HeaderProps) => {
                             application. For screen readers, use the 'Open form in new tab' icon link to allow your
                             screen reader to properly read out and allow you to work with form fields.
                         </div>
-                        <h2>Labels and tool tips</h2>
+                        <h2>Labels and Tool Tips</h2>
                         <div>
                             Labels and tool tips have been added to provide additional explanation for areas, fields and
                             actions within the application. Some of these labels may be hidden visually but will be read

--- a/packages/employer-client/src/CustomHeader.tsx
+++ b/packages/employer-client/src/CustomHeader.tsx
@@ -155,7 +155,7 @@ export const Header = (props: HeaderProps) => {
                             application. For screen readers, use the 'Open form in new tab' icon link to allow your
                             screen reader to properly read out and allow you to work with form fields.
                         </div>
-                        <h2>Labels and tool tips</h2>
+                        <h2>Labels and Tool Tips</h2>
                         <div>
                             Labels and tool tips have been added to provide additional explanation for areas, fields and
                             actions within the application. Some of these labels may be hidden visually but will be read


### PR DESCRIPTION
As per Kelly's request:
"Labels and tool tips" -> "Labels and Tool Tips"
On click of W3 Developing for Web Accessibility opens a new tab, instead of staying in the same tab.
